### PR TITLE
Set io.netty.native.workdir on application master

### DIFF
--- a/java/src/main/java/com/anaconda/skein/Daemon.java
+++ b/java/src/main/java/com/anaconda/skein/Daemon.java
@@ -233,6 +233,7 @@ public class Daemon {
     List<String> commands = Arrays.asList(
         (Environment.JAVA_HOME.$$() + "/bin/java "
          + "-Xmx128M "
+         + "-Dio.netty.native.workdir=./ "
          + "com.anaconda.skein.ApplicationMaster "
          + appDir
          + " >" + logdir + "/appmaster.log 2>&1"));


### PR DESCRIPTION
Should allow running on nodes with noexec set for /tmp.

Fixes #7.