### PR TITLE
Recipes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -183,7 +183,7 @@ setup(name='skein',
                    "Topic :: System :: Systems Administration",
                    "Topic :: System :: Distributed Computing"],
       keywords='YARN HDFS hadoop distributed cluster',
-      packages=['skein', 'skein.proto'],
+      packages=['skein', 'skein.proto', 'skein.recipes'],
       package_data={'skein': ['java/*.jar']},
       entry_points='''
         [console_scripts]

--- a/skein/recipes/ipython_kernel.py
+++ b/skein/recipes/ipython_kernel.py
@@ -1,0 +1,74 @@
+from __future__ import absolute_import, print_function, division
+
+import os
+import json
+import socket
+
+from ipykernel.kernelapp import IPKernelApp
+
+from ..core import ApplicationClient
+
+
+class SkeinIPKernelApp(IPKernelApp):
+    """A remote ipython kernel setup to run in a YARN container
+    and publish its address to the skein application master.
+
+    Examples
+    --------
+    Create an application specification:
+
+    >>> from skein import Client, ApplicationSpec, Service, Resources
+    >>> ipykernel = Service(resources=Resources(memory=2048, vcores=1),
+    ...                     files={'environment': 'environment.tar.gz'},
+    ...                     commands=['source environment/bin/activate',
+    ...                               'python -m skein.recipes.ipython_kernel'])
+    >>> spec = ApplicationSpec(name='ipython-kernel',
+    ...                        services={'ipykernel': ipykernel})
+
+    Launch the application:
+
+    >>> client = Client()
+    >>> app = client.submit(spec)
+
+    Wait until application has started:
+
+    >>> app_client = app.connect()
+
+    Get the connection information:
+
+    >>> import json
+    >>> info = json.loads(app_client.kv.wait('ipykernel.info'))
+
+    Use the connection info as you see fit for your application. When written
+    to a file, this can be used with ``jupyter console --existing file.json``
+    to connect to the remote kernel.
+    """
+    ip = '0.0.0.0'
+
+    def initialize(self, argv=None):
+        super(SkeinIPKernelApp, self).initialize(argv=argv)
+        self.skein_app_client = ApplicationClient.from_current()
+
+    def write_connection_file(self):
+        super(SkeinIPKernelApp, self).write_connection_file()
+
+        with open(self.abs_connection_file, 'r') as fil:
+            data = json.loads(fil.read())
+
+        if data['ip'] in ('', '0.0.0.0'):
+            data['ip'] = socket.gethostbyname(socket.gethostname())
+        print(data)
+
+        self.skein_app_client.kv['ipykernel.info'] = json.dumps(data)
+
+
+def start_ipython_kernel(argv=None):
+    if os.environ.get('JUPYTER_RUNTIME_DIR') is None:
+        if not os.path.exists('.jupyter'):
+            os.mkdir('.jupyter')
+        os.environ['JUPYTER_RUNTIME_DIR'] = './.jupyter'
+    SkeinIPKernelApp.launch_instance(argv=argv)
+
+
+if __name__ == '__main__':
+    start_ipython_kernel()

--- a/skein/recipes/jupyter_notebook.py
+++ b/skein/recipes/jupyter_notebook.py
@@ -1,0 +1,78 @@
+from __future__ import absolute_import, print_function, division
+
+import os
+import json
+import socket
+
+from notebook.notebookapp import NotebookApp
+
+from ..core import ApplicationClient
+
+
+class SkeinNotebookApp(NotebookApp):
+    """A jupyter notebook server setup to run in a YARN container
+    and publish its address to the skein application master.
+
+    Examples
+    --------
+    Create an application specification:
+
+    >>> from skein import Client, ApplicationSpec, Service, Resources
+    >>> notebook = Service(resources=Resources(memory=2048, vcores=1),
+    ...                    files={'environment': 'environment.tar.gz'},
+    ...                    commands=['source environment/bin/activate',
+    ...                              'python -m skein.recipes.jupyter_notebook'])
+    >>> spec = ApplicationSpec(name='jupyter-notebook',
+    ...                        services={'notebook': notebook})
+
+    Launch the application:
+
+    >>> client = Client()
+    >>> app = client.submit(spec)
+
+    Wait until application has started:
+
+    >>> app_client = app.connect()
+
+    Get the connection information:
+
+    >>> import json
+    >>> info = json.loads(app_client.kv.wait('notebook.info'))
+
+    Use the connection info as you see fit for your application. Information
+    provided includes:
+
+    - protocol (http or https)
+    - host
+    - port
+    - base_url
+    - token
+    """
+    ip = '0.0.0.0'
+    open_browser = False
+
+    def initialize(self, argv=None):
+        super(SkeinNotebookApp, self).initialize(argv=argv)
+        self.skein_app_client = ApplicationClient.from_current()
+
+    def write_server_info_file(self):
+        super(SkeinNotebookApp, self).write_server_info_file()
+
+        data = {'protocol': 'https' if self.certfile else 'http',
+                'host': socket.gethostname(),
+                'port': self.port,
+                'base_url': self.base_url,
+                'token': self.token}
+
+        self.skein_app_client.kv['notebook.info'] = json.dumps(data)
+
+
+def start_notebook_application(argv=None):
+    if os.environ.get('JUPYTER_RUNTIME_DIR') is None:
+        os.mkdir('.jupyter')
+        os.environ['JUPYTER_RUNTIME_DIR'] = './.jupyter'
+    SkeinNotebookApp.launch_instance(argv=argv)
+
+
+if __name__ == '__main__':
+    start_notebook_application()

--- a/skein/recipes/jupyter_notebook.py
+++ b/skein/recipes/jupyter_notebook.py
@@ -69,7 +69,8 @@ class SkeinNotebookApp(NotebookApp):
 
 def start_notebook_application(argv=None):
     if os.environ.get('JUPYTER_RUNTIME_DIR') is None:
-        os.mkdir('.jupyter')
+        if not os.path.exists('.jupyter'):
+            os.mkdir('.jupyter')
         os.environ['JUPYTER_RUNTIME_DIR'] = './.jupyter'
     SkeinNotebookApp.launch_instance(argv=argv)
 


### PR DESCRIPTION
This adds a `skein.recipes` module for common integrations. To start off I've added recipes for starting a remote ipython kernel, and a jupyter notebook server.

I'm not 100% set on having these live in `skein` proper, but the code is short and easy to maintain, and doesn't really feel worth having as an external library. Keeping them in a recipes module sounds fine for now.