### PR TITLE
Add `shutdown` method to `ApplicationClient`

### DIFF
--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -175,6 +175,8 @@ message ApplicationsResponse {
 
 
 service Master {
+  rpc shutdown (ShutdownRequest) returns (Empty);
+
   rpc keyvalueGetKey (GetKeyRequest) returns (GetKeyResponse);
 
   rpc keyvalueSetKey (SetKeyRequest) returns (Empty);
@@ -192,6 +194,11 @@ service Master {
   rpc killContainer (ContainerInstance) returns (Empty);
 
   rpc scale (ScaleRequest) returns (ContainersResponse);
+}
+
+
+message ShutdownRequest {
+  FinalStatus.Type final_status = 1;
 }
 
 

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -249,6 +249,15 @@ def application_kill(app_id):
 
 
 @subcommand(application.subs,
+            'shutdown', 'Shutdown a Skein application',
+            app_id,
+            arg('--status', default='SUCCEEDED',
+                help='Final Application Status. Default is SUCCEEDED'))
+def application_shutdown(app_id, status):
+    Client.from_global_daemon().connect(app_id).shutdown(status)
+
+
+@subcommand(application.subs,
             'describe', 'Get specifications for a running skein application',
             app_id,
             arg('--service', '-s', help='Service name'))

--- a/skein/core.py
+++ b/skein/core.py
@@ -20,7 +20,8 @@ from .exceptions import (context, FileNotFoundError, SkeinConfigurationError,
                          ConnectionError, ApplicationNotRunningError,
                          ApplicationError, DaemonNotRunningError, DaemonError)
 from .model import (ApplicationSpec, Service, ApplicationReport,
-                    ApplicationState, ContainerState, Container)
+                    ApplicationState, ContainerState, Container,
+                    FinalStatus)
 from .utils import cached_property, with_finalizers
 
 
@@ -588,6 +589,19 @@ class ApplicationClient(_ClientBase):
 
     def __repr__(self):
         return 'ApplicationClient<%s>' % self.address
+
+    def shutdown(self, status='SUCCEEDED'):
+        """Shutdown the application.
+
+        Stop all running containers and shutdown the application.
+
+        Parameters
+        ----------
+        status : FinalStatus, optional
+            The final application status. Default is 'SUCCEEDED'.
+        """
+        status = str(FinalStatus(status))
+        self._call('shutdown', proto.ShutdownRequest(final_status=status))
 
     @cached_property
     def kv(self):

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -5,5 +5,5 @@ from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
                         ApplicationReport, Application, ApplicationsRequest,
                         Url, ServiceRequest, GetKeyRequest, SetKeyRequest,
                         DelKeyRequest, ContainersRequest, Container,
-                        ContainerInstance, ScaleRequest)
+                        ContainerInstance, ScaleRequest, ShutdownRequest)
 from .skein_pb2_grpc import DaemonStub, MasterStub

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -156,6 +156,15 @@ def test_simple_app(client):
     assert report.id in {a.id for a in killed_apps}
 
 
+def test_shutdown_app(client):
+    with run_sleeper_app(client) as app:
+        ac = app.connect()
+
+        ac.shutdown(status='SUCCEEDED')
+
+    assert app.status().final_status == 'SUCCEEDED'
+
+
 def test_describe(client):
     with run_sleeper_app(client) as app:
         ac = app.connect()


### PR DESCRIPTION
Allows for stopping an application master without explicitly killing it.