### PR TITLE
Test user permissions in containers

### DIFF
--- a/continuous_integration/travis/docker_install.sh
+++ b/continuous_integration/travis/docker_install.sh
@@ -4,7 +4,7 @@ set -xe
 packages="grpcio pyyaml cryptography pytest flake8"
 
 if [[ $1 == "2.7" ]]; then
-    conda create -n py27 python=2.7 $packages
+    conda create -n py27 python=2.7 backports.weakref $packages
     source activate py27
 else
     conda install $packages

--- a/continuous_integration/travis/install_conda.sh
+++ b/continuous_integration/travis/install_conda.sh
@@ -1,4 +1,0 @@
-wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
-bash miniconda.sh -b -p $HOME/miniconda
-export PATH="$HOME/miniconda/bin:$PATH"
-conda config --set always_yes yes --set changeps1 no

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -531,10 +531,15 @@ public class ApplicationMaster {
     public synchronized void initialize() throws IOException {
       LOG.info("INTIALIZING: " + name);
       // Add appmaster address to environment
-      service.getEnv().put("SKEIN_APPMASTER_ADDRESS", hostname + ":" + port);
+      Map<String, String> env = service.getEnv();
+      env.put("SKEIN_APPMASTER_ADDRESS", hostname + ":" + port);
+      if (ugi.isSecurityEnabled()) {
+        // Add HADOOP_USER_NAME to environment for *simple* authentication only
+        env.put("HADOOP_USER_NAME", ugi.getUserName());
+      }
 
       ctx = ContainerLaunchContext.newInstance(
-          service.getLocalResources(), service.getEnv(), service.getCommands(),
+          service.getLocalResources(), env, service.getCommands(),
           null, tokens, null);
 
       // Request initial containers

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,8 @@ SKEIN_JAVA_DIR = os.path.join(ROOT_DIR, 'skein', 'java')
 SKEIN_JAR = os.path.join(SKEIN_JAVA_DIR, 'skein.jar')
 SKEIN_PROTO_DIR = os.path.join(ROOT_DIR, 'skein', 'proto')
 
+PY2 = sys.version_info.major == 2
+
 
 class build_proto(Command):
     description = "build protobuf artifacts"
@@ -150,6 +152,15 @@ else:
     setup_requires = []
 
 
+install_requires = ['grpcio>=1.11.0',
+                    'protobuf>=3.5.0',
+                    'pyyaml',
+                    'cryptography']
+
+if PY2:
+    install_requires.append('backports.weakref')
+
+
 # Due to quirks in setuptools/distutils dependency ordering, to get the java
 # and protobuf sources to build automatically in most cases, we need to check
 # for them in multiple locations. This is unfortunate, but seems necessary.
@@ -189,9 +200,6 @@ setup(name='skein',
         [console_scripts]
         skein=skein.cli:main
       ''',
-      install_requires=['grpcio>=1.11.0',
-                        'protobuf>=3.5.0',
-                        'pyyaml',
-                        'cryptography'],
+      install_requires=install_requires,
       setup_requires=setup_requires,
       zip_safe=False)

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -8,7 +8,7 @@ import yaml
 
 import skein
 from skein.cli import main
-from skein.test.conftest import (run_sleeper_app, sleep_until_killed,
+from skein.test.conftest import (run_application, sleep_until_killed,
                                  check_is_shutdown, wait_for_containers)
 
 
@@ -313,7 +313,7 @@ def test_cli_application(tmpdir, capsys, global_client):
 
 
 def test_cli_kv(global_client, capsys):
-    with run_sleeper_app(global_client) as app:
+    with run_application(global_client) as app:
         # Wait until started
         app.connect()
         app_id = app.app_id
@@ -358,7 +358,7 @@ def test_cli_kv(global_client, capsys):
 
 
 def test_cli_container(global_client, capsys):
-    with run_sleeper_app(global_client) as app:
+    with run_application(global_client) as app:
         app_id = app.app_id
 
         ac = app.connect()

--- a/skein/test/test_utils.py
+++ b/skein/test/test_utils.py
@@ -97,7 +97,7 @@ def test_with_finalizers_del_warns_on_exception(capsys):
     assert log == [('a', 2), ('a', 1)]
 
 
-def test_with_finalizers_finalize_raises_on_exception():
+def test_with_finalizers_finalize_raises_on_exception(capsys):
     log = []
 
     def finalizer(tag):
@@ -110,6 +110,16 @@ def test_with_finalizers_finalize_raises_on_exception():
         a._finalize()
 
     assert log == [('a', 2)]
+
+    # doesn't raise again
+    a._finalize()
+
+    # deleting object runs second finalizer, prints to stderr
+    del a
+    out, err = capsys.readouterr()
+
+    assert not out
+    assert "('a', 1)" in err
 
 
 def test_humanize_timedelta():

--- a/skein/utils.py
+++ b/skein/utils.py
@@ -6,75 +6,9 @@ from .compatibility import PY2, add_method, unicode
 
 
 if PY2:
-    def _with_finalizers(cls):
-        _finalizers = weakref.WeakKeyDictionary()
-
-        import atexit
-        import sys
-
-        def run_finalizers(finalizers, error=False):
-            while finalizers:
-                # Pop off the stack to clear the list in place
-                try:
-                    f = finalizers.pop()
-                except IndexError:  # pragma: no cover
-                    break
-                if error:
-                    f()
-                else:
-                    try:
-                        f()
-                    except Exception as exc:
-                        print("Exception %r ignored" % exc, file=sys.stderr)
-
-        @atexit.register
-        def _run_remaining_finalizers():  # pragma: no cover
-            # Grab all finalizers here to ensure that they get run
-            # even if the reference is dropped later on. Otherwise the
-            # `_finalizers` dict might change size while iterating.
-            for func_stack in list(_finalizers.values()):
-                run_finalizers(func_stack)
-
-        @add_method(cls)
-        def _add_finalizer(self, func, *args, **kwargs):
-            def thunk():
-                func(*args, **kwargs)
-
-            if self not in _finalizers:
-                _finalizers[self] = self._finalizers = []
-
-            _finalizers[self].append(thunk)
-
-        @add_method(cls)
-        def _finalize(self):
-            # If `_finalize` is called explicitly, don't silence errors
-            run_finalizers(getattr(self, '_finalizers', ()), error=True)
-
-        # We add a `__del__` method so that *usually* all the finalizers get
-        # run when the object is collected. If the __del__ method is skipped,
-        # then they'll still get run, just on shutdown.
-        @add_method(cls)
-        def __del__(self):
-            run_finalizers(getattr(self, '_finalizers', ()))
-
-        return cls
+    from backports.weakref import finalize
 else:
-    def _with_finalizers(cls):
-        _finalizers = weakref.WeakKeyDictionary()
-
-        @add_method(cls)
-        def _finalize(self):
-            for f in reversed(_finalizers.pop(self, ())):
-                f()
-
-        @add_method(cls)
-        def _add_finalizer(self, func, *args, **kwargs):
-            if self not in _finalizers:
-                _finalizers[self] = []
-            thunk = weakref.finalize(self, func, *args, **kwargs)
-            _finalizers[self].append(thunk)
-
-        return cls
+    from weakref import finalize
 
 
 def with_finalizers(cls):
@@ -83,15 +17,30 @@ def with_finalizers(cls):
     Objects should register handlers during operation using
     ``self._add_finalizer``. On cleanup, these finalizers will be called in the
     reverse order that they're added. Objects can also call ``self._finalize``
-    to explicitly trigger finalization. The cleanup functions are only run
-    once.
+    to explicitly trigger finalization. Each finalizer is only run once, even
+    upon error. If ``self._finalize`` is called explicitly and an exception
+    occurs in one of the finalizers, the remaining finalizers won't be run until
+    the object is collected, even if ``self._finalize`` is called again.
 
     On Python 3, finalizers are guaranteed to be run as soon as object is
-    collected. On Python 2 the finalizers usually are one when the object is
+    collected. On Python 2 the finalizers usually are run when the object is
     collected, but in certain situations with reference cycles, they may not
     run until program termination.
     """
-    return _with_finalizers(cls)
+    _finalizers = weakref.WeakKeyDictionary()
+
+    @add_method(cls)
+    def _finalize(self):
+        for f in reversed(_finalizers.pop(self, ())):
+            f()
+
+    @add_method(cls)
+    def _add_finalizer(self, func, *args, **kwargs):
+        if self not in _finalizers:
+            _finalizers[self] = []
+        _finalizers[self].append(finalize(self, func, *args, **kwargs))
+
+    return cls
 
 
 def ensure_unicode(x):


### PR DESCRIPTION
Previously run containers with *simple* authentication wouldn't be able
to access hdfs as the user. This is now fixed by setting the
`HADOOP_USER_NAME` environment variable in each container. Note that
`whoami` will still report as `yarn` (or whatever the yarn nodemanager
was started as) under *simple* authentication. As far as I can tell,
the only way to get around this would be to change the login at a
service level, I don't think there's a way to get yarn to start a
container as a user when using *simple* authentication.

Of course all of this already worked fine for kerberos, showing that
even when something is called "simple" with hadoop security, it's not
really "simple".

Also, use the `finalize` implementation from `backports.weakref` on
python 2 instead of rolling our own.