### PR TITLE
Automatically initialize configuration

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -9,19 +9,6 @@ using the commandline -- for more information please see the `API <api.html>`__
 or `CLI <cli.html>`__ documentation.
 
 
-Initialize Configuration
-------------------------
-
-Skein relies on a ``.skein`` directory in your home directory to store security
-credentials and runtime state. To initialize this directory, run `skein init
-<cli.html#skein-init>`__. Note that this only needs to be done once upon
-install.
-
-.. code::
-
-    $ skein init
-
-
 Kinit (optional)
 ----------------
 

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -43,6 +43,7 @@ def fail(msg, prefix=True):
     if prefix:
         msg = 'Error: %s' % msg
     print(msg, file=sys.stderr)
+    context.is_cli = False  # contextmanager skipped by SystemExit
     sys.exit(1)
 
 

--- a/skein/core.py
+++ b/skein/core.py
@@ -16,9 +16,9 @@ import grpc
 
 from . import proto
 from .compatibility import PY2, makedirs
-from .exceptions import (context, FileNotFoundError, SkeinConfigurationError,
-                         ConnectionError, ApplicationNotRunningError,
-                         ApplicationError, DaemonNotRunningError, DaemonError)
+from .exceptions import (context, FileNotFoundError, ConnectionError,
+                         ApplicationNotRunningError, ApplicationError,
+                         DaemonNotRunningError, DaemonError)
 from .model import (ApplicationSpec, Service, ApplicationReport,
                     ApplicationState, ContainerState, Container,
                     FinalStatus)
@@ -66,9 +66,9 @@ class Security(namedtuple('Security', ['cert_path', 'key_path'])):
             return cls.from_directory(CONFIG_DIR)
         except FileNotFoundError:
             pass
-        raise SkeinConfigurationError(
-            "Skein global configuration directory is not initialized. "
-            "Please run ``skein init``.")
+        context.warn("Skein global security credentials not found, writing now "
+                     "to %r." % CONFIG_DIR)
+        return cls.from_new_directory(directory=CONFIG_DIR)
 
     @classmethod
     def from_directory(cls, directory):

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -10,6 +10,23 @@ import pytest
 import skein
 
 
+@contextmanager
+def set_skein_config(tmpdir):
+    tmpdir = str(tmpdir)
+    old = skein.core.CONFIG_DIR
+    try:
+        skein.core.CONFIG_DIR = tmpdir
+        yield tmpdir
+    finally:
+        skein.core.CONFIG_DIR = old
+
+
+@pytest.fixture
+def skein_config(tmpdir_factory):
+    with set_skein_config(tmpdir_factory.mktemp('config')) as config:
+        yield config
+
+
 @pytest.fixture(scope="session")
 def security(tmpdir_factory):
     return skein.Security.from_new_directory(str(tmpdir_factory.mktemp('security')))

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 
 import skein
+from skein.exceptions import context
 from skein.cli import main
 from skein.test.conftest import (run_application, sleep_until_killed,
                                  check_is_shutdown, wait_for_containers,
@@ -29,6 +30,7 @@ services:
 def run_command(command, error=False):
     with pytest.raises(SystemExit) as exc:
         main([arg for arg in command.split(' ') if arg])
+    assert not context.is_cli
     if error:
         assert exc.value.code != 0
     else:

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -39,6 +39,22 @@ def test_security(tmpdir):
         skein.Security.from_directory(path)
 
 
+def test_security_auto_inits(skein_config):
+    with pytest.warns(None) as rec:
+        sec = skein.Security.from_default()
+
+    assert len(rec) == 1
+    assert 'Skein global security credentials not found' in str(rec[0])
+    assert os.path.exists(sec.cert_path)
+    assert os.path.exists(sec.key_path)
+
+    with pytest.warns(None) as rec:
+        sec2 = skein.Security.from_default()
+
+    assert not rec
+    assert sec == sec2
+
+
 def pid_exists(pid):
     try:
         os.kill(pid, 0)


### PR DESCRIPTION
No longer require running `skein init` before anything else. Now
defaults will be written (with a warning) on the first call
automatically.