### PR TITLE
Support relative paths

### DIFF
--- a/skein/model.py
+++ b/skein/model.py
@@ -296,7 +296,7 @@ class Base(object):
 
     def _check_is_dict_of(self, field, key, val):
         if not is_dict_of(getattr(self, field), key, val):
-            msg = "%s must be a list of %s -> %s"
+            msg = "%s must be a dict of %s -> %s"
             raise context.TypeError(msg % (field, typename(key), typename(val)))
 
     def _check_is_bounded_int(self, field, min=0, nullable=False):
@@ -507,7 +507,7 @@ class File(Base):
                 if origin is not None:
                     path = os.path.normpath(os.path.join(origin, url.path))
                 else:
-                    raise ValueError("paths must be absolute")
+                    path = os.path.abspath(url.path)
             else:
                 path = url.path
             return 'file://%s%s' % (url.netloc, path)

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -110,9 +110,6 @@ def test_file_invariants():
     with pytest.raises(ValueError):
         File('/foo/bar.zip', visibility='invalid')
 
-    with pytest.raises(ValueError):
-        File('foo/bar.zip')
-
     fil = File(source='/test/path')
 
     with pytest.raises(ValueError):
@@ -120,6 +117,19 @@ def test_file_invariants():
 
     with pytest.raises(ValueError):
         fil.visibility = 'invalid'
+
+    # relative paths
+    sol = 'file://%s' % os.path.join(os.getcwd(), 'foo/bar.zip')
+    assert File('foo/bar.zip').source == sol
+
+    # relative path, with _origin specified (only used when reading from file)
+    f = File.from_dict({'source': '../../file'}, _origin='/path/to/origin/spot')
+    assert f.source == 'file:///path/to/file'
+
+    # scheme specified
+    assert File('hdfs:///foo/bar.zip').source == 'hdfs:///foo/bar.zip'
+    assert (File('hdfs://foo.com:9000/foo/bar.zip').source ==
+            'hdfs://foo.com:9000/foo/bar.zip')
 
     assert (File(source='/test/path', type='file') ==
             File(source='/test/path', type='FILE'))


### PR DESCRIPTION
Previously we'd error if relative paths were used in code (not in a
specification file). While usually using absolute paths is more robust,
for interactive uses relative paths can be nice.