### PR TITLE
Cli nicities

### DIFF
--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -20,12 +20,13 @@ make sure you have an active ticket-granting-ticket before continuing:
     $ kinit
 
 
-Start the Skein Daemon
-----------------------
+Start the Skein Daemon (optional)
+---------------------------------
 
 To communicate with the YARN Resource manager, Skein uses a background daemon
-process written in Java. How this process is managed is configurable, but for
-most users the pattern will be:
+process written in Java. Since this process can be slow to start, sometimes it
+can be nice to start it once and have it persist through all CLI calls. This
+may look like:
 
 1. Start the Skein daemon
 2. Run yarn application/applications
@@ -38,6 +39,9 @@ To do this from the command line, use `skein daemon start
 
     $ skein daemon start
     localhost:12345
+
+Note that if you don't start the daemon process, one will be started for you,
+but not persisted between calls.
 
 
 Write an Application Specification
@@ -158,10 +162,11 @@ use the `skein application kill <cli.html#skein-application-kill>`__ command:
     application_1526497750451_0009    hello_world    KILLED    KILLED    0             0         0
 
 
-Stop the Skein Daemon
----------------------
+Stop the Skein Daemon (optional)
+--------------------------------
 
-Once you've completed your work, you can shutdown the Skein daemon. This isn't
+If you started the Daemon process (see `Start the Skein Daemon (optional)`_
+above), you'll probably want to shut it down when you're done.  This isn't
 strictly necessary (the daemon can run for long periods), but helps keep
 resource usage on the edge node low.
 

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -334,17 +334,32 @@ def container_scale(app_id, service, number):
     application_client_from_app_id(app_id).scale(service, number)
 
 
-################
-# INIT COMMAND #
-################
+##################
+# CONFIG COMMAND #
+##################
+
+config = node(entry_subs, 'config', 'Manage skein configuration')
 
 
+@subcommand(config.subs,
+            'gencerts',
+            'Generate security credentials. Creates a self-signed TLS '
+            'key/certificate pair for securing Skein communication, and writes '
+            'it to the skein configuration directory ("~.skein/" by default).',
+            arg('--force', '-f', action='store_true',
+                help='Overwrite existing configuration'))
+def config_gencerts(force=False):
+    Security.from_new_directory(force=force)
+
+
+# deprecated
 @subcommand(entry_subs,
-            'init', 'Initialize skein configuration',
+            'init', '[deprecated]',
             arg('--force', '-f', action='store_true',
                 help='Overwrite existing configuration'))
 def entry_init(force=False):
-    Security.from_new_directory(force=force)
+    context.warn("Deprecated, will be removed in next release")
+    config_gencerts(force=force)
 
 
 def main(args=None):

--- a/skein/core.py
+++ b/skein/core.py
@@ -84,10 +84,10 @@ class Security(namedtuple('Security', ['cert_path', 'key_path'])):
     def from_new_directory(cls, directory=None, force=False):
         """Create a Security object from a new certificate/key pair.
 
-        This is equivalent to the cli command ``skein init`` with the option to
-        specify an alternate directory *if needed*. Should only need to be
-        called once per user upon install. Call again with ``force=True`` to
-        generate new TLS keys and certificates.
+        This is equivalent to the cli command ``skein config gencerts`` with
+        the option to specify an alternate directory *if needed*. Should only
+        need to be called once per user upon install. Call again with
+        ``force=True`` to generate new TLS keys and certificates.
 
         Parameters
         ----------

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -57,7 +57,7 @@ def stop_global_daemon():
 @pytest.fixture(scope='module')
 def global_client(kinit, tmpdir_factory):
     with set_skein_config(tmpdir_factory.mktemp('config')):
-        run_command('init')
+        run_command('config gencerts')
         try:
             run_command('daemon start')
             yield skein.Client.from_global_daemon()
@@ -67,7 +67,8 @@ def global_client(kinit, tmpdir_factory):
 
 @pytest.mark.parametrize('command',
                          ['',
-                          'init',
+                          'config',
+                          'config gencerts',
                           'daemon',
                           'daemon start',
                           'daemon stop',
@@ -114,9 +115,9 @@ def test_cli_version(capsys):
     assert skein.__version__ in out
 
 
-def test_cli_init(capsys, skein_config):
-    # Init on clean directory
-    run_command('init')
+def test_cli_config_gencerts(capsys, skein_config):
+    # Generate certificates in clean directory
+    run_command('config gencerts')
     out, err = capsys.readouterr()
     assert not err
     assert not out
@@ -129,7 +130,7 @@ def test_cli_init(capsys, skein_config):
         key = f.read()
 
     # Running again fails due to missing --force
-    run_command('init', error=True)
+    run_command('config gencerts', error=True)
     out, err = capsys.readouterr()
     assert not out
     assert err.startswith('Error: ')
@@ -146,7 +147,7 @@ def test_cli_init(capsys, skein_config):
     assert key == key2
 
     # Run again with --force
-    run_command('init --force')
+    run_command('config gencerts --force')
     out, err = capsys.readouterr()
     assert not out
     assert not err
@@ -177,7 +178,7 @@ def test_cli_daemon(capsys, skein_config):
         assert not out
         assert 'No skein daemon is running' in err
 
-        # Start daemon without init
+        # Start daemon without generating certificates
         run_command('daemon start')
         out, err = capsys.readouterr()
         assert "Skein global security credentials not found" in err

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -163,11 +163,11 @@ def test_cli_config_gencerts(capsys, skein_config):
     assert key != key2
 
 
-def test_cli_daemon_not_running(capsys, skein_config):
-    run_command('application ls', error=True)
-    out, err = capsys.readouterr()
-    assert not out
-    assert 'Skein daemon not found' in err
+def test_works_if_cli_daemon_not_running(capfd, skein_config):
+    run_command('application ls')
+    out, err = capfd.readouterr()
+    assert 'APPLICATION_ID' in out
+    assert 'INFO' in err  # daemon logs go to stderr
 
 
 def test_cli_daemon(capsys, skein_config):


### PR DESCRIPTION
- Rename `init` to `config gencerts`
- Don't require daemon running before cli commands (fixes #25).