### PR TITLE
Container environment variables

### DIFF
--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -193,6 +193,8 @@ public class Model {
               + "instance: " + instance + ">");
     }
 
+    public String getId() { return serviceName + "_" + instance; }
+
     public void setServiceName(String serviceName) { this.serviceName = serviceName; }
     public String getServiceName() { return serviceName; }
 


### PR DESCRIPTION
Adds more information to a running container environment:

- `SKEIN_APPLICATION_ID` is the application id.
- `SKEIN_CONTAINER_ID` is the *skein* container id (e.g.
  `{service_name}_{instance_number}`). The YARN container id is provided
  by YARN at `CONTAINER_ID`.
- `SKEIN_RESOURCE_VCORES` and `SKEIN_RESOURCE_MEMORY` indicate the
  actual vcore and memory limits for the container.

Fixes #32.