### PR TITLE
Rewrite Key Value store

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -99,6 +99,17 @@ Key Value Store
 
 .. autofunction:: skein.kv.is_operation
 
+.. autoclass:: skein.kv.EventType
+    :members:
+
+.. autoclass:: skein.kv.Event
+
+.. autoclass:: skein.kv.EventFilter
+
+.. autoclass:: skein.kv.EventQueue
+    :members:
+    :inherited-members:
+
 
 Application Specification
 -------------------------

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -45,7 +45,7 @@ Key Value Store
 .. autoclass:: skein.kv.list_keys
     :members:
 
-.. autoclass:: skein.kv.contains
+.. autoclass:: skein.kv.exists
     :members:
 
 .. autoclass:: skein.kv.missing
@@ -108,7 +108,6 @@ Key Value Store
 
 .. autoclass:: skein.kv.EventQueue
     :members:
-    :inherited-members:
 
 
 Application Specification

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -30,7 +30,55 @@ Application Client
 Key Value Store
 ---------------
 
-.. autoclass:: skein.core.KeyValueStore
+.. autoclass:: skein.kv.KeyValueStore
+    :members:
+
+.. autoclass:: skein.kv.ValueOwnerPair
+    :members:
+
+.. autoclass:: skein.kv.count
+    :members:
+
+.. autoclass:: skein.kv.count
+    :members:
+
+.. autoclass:: skein.kv.list_keys
+    :members:
+
+.. autoclass:: skein.kv.contains
+    :members:
+
+.. autoclass:: skein.kv.get
+    :members:
+
+.. autoclass:: skein.kv.get_prefix
+    :members:
+
+.. autoclass:: skein.kv.get_range
+    :members:
+
+.. autoclass:: skein.kv.pop
+    :members:
+
+.. autoclass:: skein.kv.pop_prefix
+    :members:
+
+.. autoclass:: skein.kv.pop_range
+    :members:
+
+.. autoclass:: skein.kv.discard
+    :members:
+
+.. autoclass:: skein.kv.discard_prefix
+    :members:
+
+.. autoclass:: skein.kv.discard_range
+    :members:
+
+.. autoclass:: skein.kv.put
+    :members:
+
+.. autoclass:: skein.kv.swap
     :members:
 
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -48,6 +48,9 @@ Key Value Store
 .. autoclass:: skein.kv.contains
     :members:
 
+.. autoclass:: skein.kv.missing
+    :members:
+
 .. autoclass:: skein.kv.get
     :members:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -32,9 +32,9 @@ Key Value Store
 
 .. autoclass:: skein.kv.KeyValueStore
     :members:
+    :inherited-members:
 
 .. autoclass:: skein.kv.ValueOwnerPair
-    :members:
 
 .. autoclass:: skein.kv.count
     :members:
@@ -83,6 +83,21 @@ Key Value Store
 
 .. autoclass:: skein.kv.swap
     :members:
+
+.. autoclass:: skein.kv.TransactionResult
+
+.. autoclass:: skein.kv.value
+    :members:
+
+.. autoclass:: skein.kv.owner
+    :members:
+
+.. autoclass:: skein.kv.comparison
+    :members:
+
+.. autofunction:: skein.kv.is_condition
+
+.. autofunction:: skein.kv.is_operation
 
 
 Application Specification

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -119,6 +119,16 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>2.22.0</version>
+        <configuration>
+          <enableAssertions>true</enableAssertions>
+        </configuration>
+      </plugin>
+
     </plugins>
   </build>
 

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -1271,5 +1271,38 @@ public class ApplicationMaster {
       resp.onNext(builder.build());
       resp.onCompleted();
     }
+
+    @Override
+    public StreamObserver<Msg.WatchRequest> watch(final StreamObserver<Msg.WatchResponse> resp) {
+      return new StreamObserver<Msg.WatchRequest>() {
+        @Override
+        public void onNext(Msg.WatchRequest req) {
+          Msg.WatchResponse.Builder builder = Msg.WatchResponse.newBuilder();
+          switch (req.getRequestCase()) {
+            case CREATE:
+              LOG.info("New watcher request");
+              builder.setWatchId(1);
+              break;
+            case CANCEL:
+              LOG.info("Cancel watcher request");
+              builder.setWatchId(1);
+              break;
+            default:
+              break;
+          }
+          resp.onNext(builder.build());
+        }
+
+        @Override
+        public void onError(Throwable t) {
+          LOG.info("Cancelled watcher");
+        }
+
+        @Override
+        public void onCompleted() {
+          resp.onCompleted();
+        }
+      };
+    }
   }
 }

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -506,8 +506,8 @@ public class ApplicationMaster {
       switch (req.getRequestCase()) {
         case CREATE:
           Msg.WatchCreateRequest create = req.getCreate();
-          String start = create.getRangeStart();
-          String end = create.getRangeEnd();
+          String start = create.getStart();
+          String end = create.getEnd();
           Msg.WatchCreateRequest.Type type = create.getEventType();
           synchronized (keyValueStore) {
             watchId = intervalTree.add(start, end, new Watcher(resp, this, type));
@@ -1072,9 +1072,8 @@ public class ApplicationMaster {
     }
 
     private Msg.GetRangeResponse.Builder evalGetRange(Msg.GetRangeRequest req) {
-      String start = req.getRangeStart();
-      String end = req.getRangeEnd();
-
+      String start = req.getStart();
+      String end = req.getEnd();
 
       Msg.GetRangeResponse.Builder builder;
 
@@ -1118,8 +1117,8 @@ public class ApplicationMaster {
 
     private Msg.DeleteRangeResponse.Builder evalDeleteRange(
         Msg.DeleteRangeRequest req) {
-      String start = req.getRangeStart();
-      String end = req.getRangeEnd();
+      String start = req.getStart();
+      String end = req.getEnd();
 
       Msg.DeleteRangeResponse.Builder builder;
 

--- a/java/src/main/java/com/anaconda/skein/IntervalTree.java
+++ b/java/src/main/java/com/anaconda/skein/IntervalTree.java
@@ -1,0 +1,531 @@
+/* The following file was copied and *heavily* modified from
+ *
+ * https://github.com/tinloaf/intervaltree/blob/master/src/de/tinloaf/intervaltree/IntervalTree.java
+ *
+ * In particular, the following changes were made:
+ *
+ * - Support left inclusive, right exclusive bounds
+ * - Specialize only for our use case
+ * - Remove unnecessary methods
+ * - Simplify and cleanup code
+ *
+ * The original source was copyrighted under the MIT license, (c) 2014 tinloaf.
+ * The original license is included in a comment at the end of this file.
+ */
+
+package com.anaconda.skein;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+
+public class IntervalTree<T> {
+  private TreeNode<T> root;
+  private Map<Integer, Item<T>> lookup;
+  private int currentId = 0;
+
+  private static enum Color {
+    RED, BLACK
+  }
+
+  public IntervalTree() {
+    this.root = null;
+    this.lookup = new HashMap<Integer, Item<T>>();
+  }
+
+  private int nextId() {
+    return currentId++;
+  }
+
+  public int size() {
+    return lookup.size();
+  }
+
+  public static class Interval {
+    private String begin;
+    private String end;
+
+    Interval(String begin, String end) {
+      this.begin = begin == null ? "" : begin;
+      // end can be null, meaning max range
+      this.end = end;
+    }
+
+    String getBegin() { return begin; }
+    String getEnd() { return end; }
+
+    @Override
+    public int hashCode() {
+      int hash = begin == null ? 0 : begin.hashCode();
+      return 31 * hash + (end == null ? 0 : end.hashCode());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+
+      if (other == null || this.getClass() != other.getClass()) {
+        return false;
+      }
+
+      Interval iother = (Interval) other;
+
+      return ((begin == null ? iother.begin == null : begin.equals(iother.begin))
+              && (end == null) ? iother.end == null : end.equals(iother.end));
+    }
+  }
+
+  public static class Item<V> {
+    private Interval interval;
+    private TreeNode<V> treenode;
+    private V value;
+    private int id;
+
+    Item(Interval interval, V value, int id) {
+      this.interval = interval;
+      this.value = value;
+      this.id = id;
+    }
+
+    Item(String begin, String end, V value, int id) {
+      this(new Interval(begin, end), value, id);
+    }
+
+    public Interval getInterval() { return interval; }
+    public int getId() { return id; }
+    public V getValue() { return value; }
+  }
+
+  private static class TreeNode<V> {
+    Interval interval;
+    Color color;
+    TreeNode<V> left;
+    TreeNode<V> right;
+    TreeNode<V> parent;
+    HashSet<Item<V>> items;
+    String max;
+
+    TreeNode(Interval interval, Color nodeColor, TreeNode<V> left, TreeNode<V> right) {
+      this.interval = interval;
+      this.color = nodeColor;
+      this.left = left;
+      this.right = right;
+      this.parent = null;
+      this.items = new HashSet<Item<V>>();
+      updateMax();
+    }
+
+    void updateMax() {
+      max = interval.end;
+
+      if (left != null) {
+        left.parent = this;
+        max = nullStringMax(max, left.max);
+      }
+
+      if (right != null) {
+        right.parent = this;
+        max = nullStringMax(max, right.max);
+      }
+    }
+
+    TreeNode<V> grandparent() {
+      return parent.parent;
+    }
+
+    TreeNode<V> sibling() {
+      return (this == parent.right) ? parent.left : parent.right;
+    }
+
+    TreeNode<V> uncle() {
+      return parent.sibling();
+    }
+
+    private List<Item<V>> query(Interval target, List<Item<V>> out) {
+      boolean eRightOfB = nullStringCompare(interval.begin, target.end) < 0;
+
+      if (eRightOfB && nullStringCompare(interval.end, target.begin) > 0) {
+        out.addAll(items);
+      }
+
+      if (left != null && nullStringCompare(left.max, target.begin) > 0) {
+        left.query(target, out);
+      }
+
+      if (right != null && eRightOfB) {
+        right.query(target, out);
+      }
+
+      return out;
+    }
+  }
+
+  public static int nullStringCompare(String a, String b) {
+    if (a == null) {
+      return b == null ? 0 : 1;
+    } else if (b == null) {
+      return -1;
+    } else {
+      return a.compareTo(b);
+    }
+  }
+
+  private static String nullStringMax(String a, String b) {
+    return nullStringCompare(a, b) < 0 ? b : a;
+  }
+
+  private Color nodeColor(TreeNode<T> n) {
+    return (n == null) ? Color.BLACK : n.color;
+  }
+
+  public List<Item<T>> query(String begin, String end) {
+    if (root == null) {
+      return Collections.emptyList();
+    }
+    return root.query(new Interval(begin, end),
+                      new ArrayList<Item<T>>(Math.round(size() * 0.5f)));
+  }
+
+  private void replaceNode(TreeNode<T> oldn, TreeNode<T> newn) {
+    if (oldn.parent == null) {
+      root = newn;
+    } else {
+      if (oldn == oldn.parent.left) {
+        oldn.parent.left = newn;
+      } else {
+        oldn.parent.right = newn;
+      }
+    }
+    if (newn != null) {
+      newn.parent = oldn.parent;
+    }
+  }
+
+  private void rotateLeft(TreeNode<T> n) {
+    TreeNode<T> r = n.right;
+    replaceNode(n, r);
+    n.right = r.left;
+    if (r.left != null) {
+      r.left.parent = n;
+    }
+    r.left = n;
+    n.parent = r;
+
+    // Update max towards root
+    n.updateMax();
+    r.updateMax();
+    if (r.parent != null) {
+      r.parent.updateMax();
+    }
+  }
+
+  private void rotateRight(TreeNode<T> n) {
+    TreeNode<T> l = n.left;
+    replaceNode(n, l);
+    n.left = l.right;
+    if (l.right != null) {
+      l.right.parent = n;
+    }
+    l.right = n;
+    n.parent = l;
+
+    // Update max towards root
+    n.updateMax();
+    l.updateMax();
+    if (l.parent != null) {
+      l.parent.updateMax();
+    }
+  }
+
+  public int add(String begin, String end, T value) {
+    Item<T> item = new Item<T>(begin, end, value, nextId());
+    TreeNode<T> newNode = new TreeNode<T>(item.interval, Color.RED, null, null);
+    lookup.put(item.id, item);
+
+    if (root == null) {
+      root = newNode;
+    } else {
+      TreeNode<T> n = root;
+      while (true) {
+        int beginComp = nullStringCompare(item.interval.begin, n.interval.begin);
+        n.max = nullStringMax(n.max, item.interval.end);
+
+        if (beginComp == 0) {
+          int endComp = nullStringCompare(item.interval.end, n.interval.end);
+          if (endComp == 0) {
+            // Match with existing interval, just add to set
+            n.items.add(item);
+            item.treenode = n;
+            return item.id;
+          } else {
+            if (endComp > 0) {
+              if (n.right == null) {
+                n.right = newNode;
+                break;
+              } else {
+                n = n.right;
+              }
+            } else {
+              if (n.left == null) {
+                n.left = newNode;
+                break;
+              } else {
+                n = n.left;
+              }
+            }
+          }
+        } else if (beginComp < 0) {
+          if (n.left == null) {
+            n.left = newNode;
+            break;
+          } else {
+            n = n.left;
+          }
+        } else {
+          if (n.right == null) {
+            n.right = newNode;
+            break;
+          } else {
+            n = n.right;
+          }
+        }
+      }
+      newNode.parent = n;
+    }
+
+    newNode.items.add(item);
+    item.treenode = newNode;
+    fixTreeAt(newNode);
+    return item.id;
+  }
+
+  private void fixTreeAt(TreeNode<T> n) {
+    /*
+     * Case 1: We are the root. We are black, everything else is still OK
+     */
+    if (n.parent == null) {
+      n.color = Color.BLACK;
+      return;
+    }
+
+    /*
+     * Case 2: Our parent is black. Two consecutive blacks are allowed, all is
+     * well.
+     */
+    if (nodeColor(n.parent) == Color.BLACK) {
+      return; // Tree is still valid
+    }
+
+    /*
+     * Case 3: We violate red-red, but our uncle is red, too. We switch the
+     * colors of (uncle/parent) and grandparent and restart fixing at our
+     * grandparent.
+     */
+    if (nodeColor(n.uncle()) == Color.RED) {
+      n.parent.color = Color.BLACK;
+      n.uncle().color = Color.BLACK;
+      n.grandparent().color = Color.RED;
+      fixTreeAt(n.grandparent());
+      return;
+    }
+
+    /*
+     * Case 4: We violate red-red, and our uncle is black. We need to rotate!
+     */
+
+    /*
+     * Sub-Case 4.1: We are "inside" our grandparents subtree, i.e. we are the
+     * left child and our parent is a right child (or vice versa). We need to
+     * rotate ourselves to the outside (by rotating about our parent) to apply
+     * the fix for case 4.
+     */
+    if (n == n.parent.right && n.parent == n.grandparent().left) {
+      rotateLeft(n.parent);
+      n = n.left;
+    } else if (n == n.parent.left && n.parent == n.grandparent().right) {
+      rotateRight(n.parent);
+      n = n.right;
+    }
+
+    /*
+     * Now, finally fix case 4 by rotating about our parent.
+     */
+    n.parent.color = Color.BLACK;
+    n.grandparent().color = Color.RED;
+    if (n == n.parent.left && n.parent == n.grandparent().left) {
+      rotateRight(n.grandparent());
+    } else {
+      assert n == n.parent.right && n.parent == n.grandparent().right;
+      rotateLeft(n.grandparent());
+    }
+  }
+
+  public boolean discard(int id) {
+    Item<T> item = lookup.remove(id);
+
+    if (item == null) {
+      return false;  // Key not found, do nothing
+    }
+
+    TreeNode<T> n = item.treenode;
+
+    if (n.items.size() > 1) {
+      // we retain the node since it contains multiple items
+      n.items.remove(item);
+      return true;
+    }
+
+    if (n.left != null && n.right != null) {
+      // Copy key/value from predecessor and then delete it instead
+      TreeNode<T> pred = maximumNode(n.left);
+      n.interval = pred.interval;
+      n.items = pred.items;
+      for (Item<T> it : n.items) {
+        it.treenode = n;
+      }
+      n = pred;
+    }
+
+    TreeNode<T> child = (n.right == null) ? n.left : n.right;
+
+    if (nodeColor(n) == Color.BLACK) {
+      n.color = nodeColor(child);
+      fixTreeForDeletion(n);
+    }
+    replaceNode(n, child);
+
+    if ((child != null) && (child.parent == null)) {
+      child.color = Color.BLACK;
+    }
+
+    // Fix all the max values from what we just deleted up to the root
+    TreeNode<T> cur = n.parent;
+    while (cur != null) {
+      cur.updateMax();
+      cur = cur.parent;
+    }
+    return true;
+  }
+
+  private void fixTreeForDeletion(TreeNode<T> n) {
+    /*
+     * Case 1: We deleted the root. All is well since we deleted one black node
+     * from every path.
+     */
+    if (n.parent == null) {
+      n.color = Color.BLACK;
+      return;
+    }
+
+    /*
+     * Case 2: We have a red sibling. Rotate about the parent to prepare for
+     * remaining cases.
+     */
+    if (nodeColor(n.sibling()) == Color.RED) {
+      n.parent.color = Color.RED;
+      n.sibling().color = Color.BLACK;
+      if (n == n.parent.left) {
+        rotateLeft(n.parent);
+      } else {
+        rotateRight(n.parent);
+      }
+    }
+
+    /*
+     * Case 3: We can recolor and recurse
+     */
+    if (nodeColor(n.parent) == Color.BLACK
+        && nodeColor(n.sibling()) == Color.BLACK
+        && nodeColor(n.sibling().left) == Color.BLACK
+        && nodeColor(n.sibling().right) == Color.BLACK) {
+      n.sibling().color = Color.RED;
+      fixTreeForDeletion(n.parent);
+      return;
+    }
+
+    /*
+     * Case 4
+     */
+    if (nodeColor(n.parent) == Color.RED
+        && nodeColor(n.sibling()) == Color.BLACK
+        && nodeColor(n.sibling().left) == Color.BLACK
+        && nodeColor(n.sibling().right) == Color.BLACK) {
+      n.sibling().color = Color.RED;
+      n.parent.color = Color.BLACK;
+      return;
+    }
+
+    /*
+     * Case 5: Prepare for case 6
+     */
+    if (n == n.parent.left
+        && nodeColor(n.sibling()) == Color.BLACK
+        && nodeColor(n.sibling().left) == Color.RED
+        && nodeColor(n.sibling().right) == Color.BLACK) {
+      n.sibling().color = Color.RED;
+      n.sibling().left.color = Color.BLACK;
+      rotateRight(n.sibling());
+    }
+    else if (n == n.parent.right
+        && nodeColor(n.sibling()) == Color.BLACK
+        && nodeColor(n.sibling().right) == Color.RED
+        && nodeColor(n.sibling().left) == Color.BLACK) {
+      n.sibling().color = Color.RED;
+      n.sibling().right.color = Color.BLACK;
+      rotateLeft(n.sibling());
+    }
+
+    /*
+     * Case 6
+     */
+    n.sibling().color = nodeColor(n.parent);
+    n.parent.color = Color.BLACK;
+    if (n == n.parent.left) {
+      assert nodeColor(n.sibling().right) == Color.RED;
+      n.sibling().right.color = Color.BLACK;
+      rotateLeft(n.parent);
+    }
+    else {
+      assert nodeColor(n.sibling().left) == Color.RED;
+      n.sibling().left.color = Color.BLACK;
+      rotateRight(n.parent);
+    }
+  }
+
+  private TreeNode<T> maximumNode(TreeNode<T> n) {
+    while (n.right != null) {
+      n = n.right;
+    }
+    return n;
+  }
+}
+
+/* License included from original source:
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2014 tinloaf
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -6,6 +6,7 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -175,6 +176,7 @@ public class Model {
     private long startTime;
     private long finishTime;
     private ContainerRequest req;
+    private Set<String> ownedKeys;
 
     public Container() {}
 
@@ -185,6 +187,7 @@ public class Model {
       this.yarnContainerId = null;
       this.startTime = 0;
       this.finishTime = 0;
+      this.ownedKeys = new HashSet<String>();
     }
 
     public String toString() {
@@ -224,5 +227,15 @@ public class Model {
       this.req = null;
       return out;
     }
+
+    public void addOwnedKey(String key) {
+      ownedKeys.add(key);
+    }
+
+    public void removeOwnedKey(String key) {
+      ownedKeys.remove(key);
+    }
+
+    public Set<String> getOwnedKeys() { return ownedKeys; }
   }
 }

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -207,6 +207,17 @@ public class Model {
     public void setState(State state) { this.state = state; }
     public State getState() { return state; }
 
+    public boolean completed() {
+      switch (state) {
+        case WAITING:
+        case REQUESTED:
+        case RUNNING:
+          return false;
+        default:
+          return true;
+      }
+    }
+
     public void setYarnContainerId(ContainerId yarnContainerId) {
       this.yarnContainerId = yarnContainerId;
     }
@@ -237,5 +248,6 @@ public class Model {
     }
 
     public Set<String> getOwnedKeys() { return ownedKeys; }
+    public void clearOwnedKeys() { ownedKeys.clear(); }
   }
 }

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -216,8 +216,8 @@ message GetRangeRequest {
     KEYS = 1;
     NONE = 2;
   }
-  string range_start = 1;
-  string range_end = 2;
+  string start = 1;
+  string end = 2;
   ResultType result_type = 3;
 }
 
@@ -251,8 +251,8 @@ message DeleteRangeRequest {
     ITEMS = 1;
     KEYS = 2;
   }
-  string range_start = 1;
-  string range_end = 2;
+  string start = 1;
+  string end = 2;
   ResultType result_type = 3;
 }
 
@@ -324,8 +324,8 @@ message WatchCreateRequest {
     PUT = 1;
     DELETE = 2;
   }
-  string range_start = 1;
-  string range_end = 2;
+  string start = 1;
+  string end = 2;
   Type event_type = 3;
 }
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -180,7 +180,7 @@ service Master {
 
   rpc GetRange (GetRangeRequest) returns (GetRangeResponse);
 
-  rpc Put (PutRequest) returns (PutResponse);
+  rpc PutKey (PutKeyRequest) returns (PutKeyResponse);
 
   rpc DeleteRange (DeleteRangeRequest) returns (DeleteRangeResponse);
 
@@ -204,6 +204,7 @@ message ShutdownRequest {
 message KeyValue {
   string key = 1;
   bytes value = 2;
+  ContainerInstance owner = 3;
 }
 
 
@@ -215,26 +216,30 @@ message GetRangeRequest {
   }
   string range_start = 1;
   string range_end = 2;
-  int32 limit = 3;
-  ResultType result_type = 4;
+  ResultType result_type = 3;
 }
 
 
 message GetRangeResponse {
-  GetRangeRequest.ResultType result_type = 1;
-  int32 count = 2;
-  repeated KeyValue kv = 3;
+  int32 count = 1;
+  GetRangeRequest.ResultType result_type = 2;
+  repeated KeyValue result = 3;
 }
 
 
-message PutRequest {
-  KeyValue kv = 1;
-  bool prev_kv = 2;
+message PutKeyRequest {
+  string key = 1;
+  bytes value = 2;
+  ContainerInstance owner = 3;
+  bool ignore_value = 4;
+  bool ignore_owner = 5;
+  bool return_previous = 6;
 }
 
 
-message PutResponse {
-  KeyValue prev_kv = 1;
+message PutKeyResponse {
+  bool return_previous = 1;
+  KeyValue previous = 2;
 }
 
 
@@ -251,9 +256,9 @@ message DeleteRangeRequest {
 
 
 message DeleteRangeResponse {
-  DeleteRangeRequest.ResultType result_type = 1;
-  int32 count = 2;
-  repeated KeyValue prev_kv = 3;
+  int32 count = 1;
+  DeleteRangeRequest.ResultType result_type = 2;
+  repeated KeyValue result = 3;
 }
 
 
@@ -278,7 +283,7 @@ message Condition {
 message RequestOp {
   oneof request {
     GetRangeRequest request_get_range = 1;
-    PutRequest request_put = 2;
+    PutKeyRequest request_put = 2;
     DeleteRangeRequest request_del_range = 3;
   }
 }
@@ -287,7 +292,7 @@ message RequestOp {
 message ResponseOp {
   oneof response {
     GetRangeResponse response_get = 1;
-    PutResponse response_put = 2;
+    PutKeyResponse response_put = 2;
     DeleteRangeResponse response_del_range = 3;
   }
 }

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -186,6 +186,8 @@ service Master {
 
   rpc Transaction (TransactionRequest) returns (TransactionResponse);
 
+  rpc Watch (stream WatchRequest) returns (stream WatchResponse);
+
   rpc getApplicationSpec (Empty) returns (ApplicationSpec);
 
   rpc getContainers (ContainersRequest) returns (ContainersResponse);
@@ -313,6 +315,53 @@ message TransactionRequest {
 message TransactionResponse {
   bool succeeded = 1;
   repeated OpResponse result = 2;
+}
+
+
+message Event {
+  enum Type {
+    PUT = 0;
+    DELETE = 1;
+  }
+  Type type = 1;
+  KeyValue result = 2;
+}
+
+
+message WatchCreateRequest {
+  enum Type {
+    ALL = 0;
+    PUT = 1;
+    DELETE = 2;
+  }
+  string range_start = 1;
+  string range_end = 2;
+  Type event_type = 3;
+}
+
+
+message WatchCancelRequest {
+  int32 watch_id = 1;
+}
+
+
+message WatchRequest {
+  oneof request {
+    WatchCreateRequest create = 1;
+    WatchCancelRequest cancel = 2;
+  }
+}
+
+
+message WatchResponse {
+  enum Type {
+    EVENT = 0;
+    CREATE = 1;
+    CANCEL = 2;
+  }
+  Type type = 1;
+  int32 watch_id = 2;
+  repeated Event event = 3;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -289,7 +289,7 @@ message OpRequest {
   oneof request {
     GetRangeRequest get_range = 1;
     PutKeyRequest put_key = 2;
-    DeleteRangeRequest del_range = 3;
+    DeleteRangeRequest delete_range = 3;
   }
 }
 
@@ -298,7 +298,7 @@ message OpResponse {
   oneof response {
     GetRangeResponse get_range = 1;
     PutKeyResponse put_key = 2;
-    DeleteRangeResponse del_range = 3;
+    DeleteRangeResponse delete_range = 3;
   }
 }
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -318,16 +318,6 @@ message TransactionResponse {
 }
 
 
-message Event {
-  enum Type {
-    PUT = 0;
-    DELETE = 1;
-  }
-  Type type = 1;
-  KeyValue result = 2;
-}
-
-
 message WatchCreateRequest {
   enum Type {
     ALL = 0;
@@ -355,13 +345,14 @@ message WatchRequest {
 
 message WatchResponse {
   enum Type {
-    EVENT = 0;
-    CREATE = 1;
-    CANCEL = 2;
+    CREATE = 0;
+    CANCEL = 1;
+    PUT = 2;
+    DELETE = 3;
   }
   Type type = 1;
   int32 watch_id = 2;
-  repeated Event event = 3;
+  repeated KeyValue event = 3;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -263,7 +263,7 @@ message DeleteRangeResponse {
 
 
 message Condition {
-  enum Op {
+  enum Operator {
     EQUAL = 0;
     NOT_EQUAL = 1;
     LESS = 2;
@@ -276,7 +276,7 @@ message Condition {
     OWNER = 1;
   }
   string key = 1;
-  Op operator = 2;
+  Operator operator = 2;
   Field field = 3;
   oneof rhs {
     bytes value = 4;
@@ -285,34 +285,34 @@ message Condition {
 }
 
 
-message RequestOp {
+message OpRequest {
   oneof request {
-    GetRangeRequest request_get_range = 1;
-    PutKeyRequest request_put = 2;
-    DeleteRangeRequest request_del_range = 3;
+    GetRangeRequest get_range = 1;
+    PutKeyRequest put_key = 2;
+    DeleteRangeRequest del_range = 3;
   }
 }
 
 
-message ResponseOp {
+message OpResponse {
   oneof response {
-    GetRangeResponse response_get = 1;
-    PutKeyResponse response_put = 2;
-    DeleteRangeResponse response_del_range = 3;
+    GetRangeResponse get_range = 1;
+    PutKeyResponse put_key = 2;
+    DeleteRangeResponse del_range = 3;
   }
 }
 
 
 message TransactionRequest {
-  repeated Condition conditions = 1;
-  repeated RequestOp on_true = 2;
-  repeated RequestOp on_false = 3;
+  repeated Condition condition = 1;
+  repeated OpRequest on_success = 2;
+  repeated OpRequest on_failure = 3;
 }
 
 
 message TransactionResponse {
   bool succeeded = 1;
-  repeated ResponseOp responses = 2;
+  repeated OpResponse result = 2;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -263,19 +263,24 @@ message DeleteRangeResponse {
 
 
 message Condition {
-  message Exists {
-    string key = 1;
+  enum Op {
+    EQUAL = 0;
+    NOT_EQUAL = 1;
+    LESS = 2;
+    LESS_EQUAL = 3;
+    GREATER = 4;
+    GREATER_EQUAL = 5;
   }
-
-  message Equals {
-    string key = 1;
-    bytes value = 2;
+  enum Field {
+    VALUE = 0;
+    OWNER = 1;
   }
-
-  bool inverse = 1;
-  oneof op {
-    Exists op_exists = 2;
-    Equals op_equals = 3;
+  string key = 1;
+  Op operator = 2;
+  Field field = 3;
+  oneof rhs {
+    bytes value = 4;
+    ContainerInstance owner = 5;
   }
 }
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -178,15 +178,13 @@ message ApplicationsResponse {
 service Master {
   rpc shutdown (ShutdownRequest) returns (Empty);
 
-  rpc keyvalueGetKey (GetKeyRequest) returns (GetKeyResponse);
+  rpc GetRange (GetRangeRequest) returns (GetRangeResponse);
 
-  rpc keyvalueSetKey (SetKeyRequest) returns (Empty);
+  rpc Put (PutRequest) returns (PutResponse);
 
-  rpc keyvalueDelKey (DelKeyRequest) returns (Empty);
+  rpc DeleteRange (DeleteRangeRequest) returns (DeleteRangeResponse);
 
-  rpc keyvalueListAll (Empty) returns (KeyValueListResponse);
-
-  rpc keyvalueGetAll (Empty) returns (KeyValueResponse);
+  rpc Transaction (TransactionRequest) returns (TransactionResponse);
 
   rpc getApplicationSpec (Empty) returns (ApplicationSpec);
 
@@ -203,33 +201,108 @@ message ShutdownRequest {
 }
 
 
-message GetKeyRequest {
+message KeyValue {
   string key = 1;
-  bool wait = 2;
+  bytes value = 2;
 }
 
 
-message GetKeyResponse {
-  bytes val = 1;
+message GetRangeRequest {
+  enum ResultType {
+    ITEMS = 0;
+    KEYS = 1;
+    NONE = 2;
+  }
+  string range_start = 1;
+  string range_end = 2;
+  int32 limit = 3;
+  ResultType result_type = 4;
 }
 
 
-message SetKeyRequest {
-  string key = 1;
-  bytes val = 2;
-}
-
-message DelKeyRequest {
-  string key = 1;
-}
-
-message KeyValueResponse {
-  map<string, bytes> items = 1;
+message GetRangeResponse {
+  GetRangeRequest.ResultType result_type = 1;
+  int32 count = 2;
+  repeated KeyValue kv = 3;
 }
 
 
-message KeyValueListResponse {
-  repeated string keys = 1;
+message PutRequest {
+  KeyValue kv = 1;
+  bool prev_kv = 2;
+}
+
+
+message PutResponse {
+  KeyValue prev_kv = 1;
+}
+
+
+message DeleteRangeRequest {
+  enum ResultType {
+    NONE = 0;
+    ITEMS = 1;
+    KEYS = 2;
+  }
+  string range_start = 1;
+  string range_end = 2;
+  ResultType result_type = 3;
+}
+
+
+message DeleteRangeResponse {
+  DeleteRangeRequest.ResultType result_type = 1;
+  int32 count = 2;
+  repeated KeyValue prev_kv = 3;
+}
+
+
+message Condition {
+  message Exists {
+    string key = 1;
+  }
+
+  message Equals {
+    string key = 1;
+    bytes value = 2;
+  }
+
+  bool inverse = 1;
+  oneof op {
+    Exists op_exists = 2;
+    Equals op_equals = 3;
+  }
+}
+
+
+message RequestOp {
+  oneof request {
+    GetRangeRequest request_get_range = 1;
+    PutRequest request_put = 2;
+    DeleteRangeRequest request_del_range = 3;
+  }
+}
+
+
+message ResponseOp {
+  oneof response {
+    GetRangeResponse response_get = 1;
+    PutResponse response_put = 2;
+    DeleteRangeResponse response_del_range = 3;
+  }
+}
+
+
+message TransactionRequest {
+  repeated Condition conditions = 1;
+  repeated RequestOp on_true = 2;
+  repeated RequestOp on_false = 3;
+}
+
+
+message TransactionResponse {
+  bool succeeded = 1;
+  repeated ResponseOp responses = 2;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -184,6 +184,8 @@ service Master {
 
   rpc keyvalueDelKey (DelKeyRequest) returns (Empty);
 
+  rpc keyvalueListAll (Empty) returns (KeyValueListResponse);
+
   rpc keyvalueGetAll (Empty) returns (KeyValueResponse);
 
   rpc getApplicationSpec (Empty) returns (ApplicationSpec);
@@ -208,13 +210,13 @@ message GetKeyRequest {
 
 
 message GetKeyResponse {
-  string val = 1;
+  bytes val = 1;
 }
 
 
 message SetKeyRequest {
   string key = 1;
-  string val = 2;
+  bytes val = 2;
 }
 
 message DelKeyRequest {
@@ -222,7 +224,12 @@ message DelKeyRequest {
 }
 
 message KeyValueResponse {
-  map<string, string> items = 1;
+  map<string, bytes> items = 1;
+}
+
+
+message KeyValueListResponse {
+  repeated string keys = 1;
 }
 
 

--- a/java/src/test/java/com/anaconda/skein/TestIntervalTree.java
+++ b/java/src/test/java/com/anaconda/skein/TestIntervalTree.java
@@ -1,0 +1,155 @@
+package com.anaconda.skein;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Suite.class)
+@Suite.SuiteClasses({TestIntervalTree.TestQuery.class,
+                     TestIntervalTree.TestDiscard.class,
+                     TestIntervalTree.TestMisc.class})
+public class TestIntervalTree {
+  public static class TestQuery {
+    IntervalTree<Integer> it;
+    int numItems;
+
+    @Before
+    public void setUp() {
+      it = new IntervalTree<Integer>();
+      /*      -oo   a   b   c   d   e   f   g   h   i   oo
+       *  ooc   |===|===|===|   |   |   |   |   |   |   |
+       *  a2c   |   |===|===|   |   |   |   |   |   |   |
+       *  a2e   |   |===|===|===|===|   |   |   |   |   |
+       *  a2i   |   |===|===|===|===|===|===|   |   |   |
+       *  b2d1  |   |   |===|===|   |   |   |   |   |   |
+       *  b2d2  |   |   |===|===|   |   |   |   |   |   |
+       *  d2f   |   |   |   |   |===|===|   |   |   |   |
+       *  doo   |   |   |   |   |===|===|===|===|===|===|
+       *  h2i   |   |   |   |   |   |   |   |   |===|   |
+       */
+      it.add(null, "c", 0);
+      it.add("a", "c", 1);
+      it.add("a", "e", 2);
+      it.add("a", "g", 3);
+      it.add("b", "d", 4);
+      it.add("b", "d", 5);
+      it.add("d", "f", 6);
+      it.add("d", null, 7);
+      it.add("h", "i", 8);
+      numItems = 9;
+    }
+
+    @Test
+    public void testQueryEmpty() {
+      IntervalTree<Integer> it = new IntervalTree<Integer>();
+
+      assertEquals(it.size(), 0);
+
+      assertEquals(0, it.query(null, null).size());
+    }
+
+    @Test
+    public void testQueryFullyInsideBounds() {
+      assertEquals(numItems, it.size());
+
+      assertEquals(1, it.query(null, "\u0000").size());
+      assertEquals(4, it.query("aa", "aaa").size());
+      assertEquals(6, it.query("bb", "bbb").size());
+      assertEquals(4, it.query("cc", "ccc").size());
+      assertEquals(4, it.query("dd", "ddd").size());
+      assertEquals(3, it.query("ee", "eee").size());
+      assertEquals(2, it.query("ff", "fff").size());
+      assertEquals(1, it.query("gg", "ggg").size());
+      assertEquals(2, it.query("hh", "hhh").size());
+      assertEquals(1, it.query("ii", null).size());
+    }
+
+    @Test
+    public void testQueryBoundsLeft() {
+      assertEquals(numItems, it.size());
+
+      assertEquals(4, it.query("a", "aa").size());
+      assertEquals(4, it.query("c", "cc").size());
+      assertEquals(1, it.query("g", "gg").size());
+    }
+
+    @Test
+    public void testQueryBoundsRight() {
+      assertEquals(numItems, it.size());
+
+      assertEquals(4, it.query("aa", "b").size());
+      assertEquals(4, it.query("cc", "d").size());
+      assertEquals(1, it.query("gg", "h").size());
+      assertEquals(1, it.query("ii", null).size());
+    }
+  }
+
+  public static class TestDiscard {
+    @Test
+    public void testDiscardNonExistant() {
+      IntervalTree<Integer> it = new IntervalTree<Integer>();
+
+      assertEquals(it.size(), 0);
+      assertFalse(it.discard(100));
+      assertEquals(it.size(), 0);
+    }
+
+    @Test
+    public void testDiscard() {
+      IntervalTree<Integer> it = new IntervalTree<Integer>();
+
+      assertEquals(0, it.size());
+
+      int ac1 = it.add("a", "c", 1);
+      int ac2 = it.add("a", "c", 2);
+      int ad = it.add("a", "d", 3);
+      int cd = it.add("c", "d", 1);
+
+      assertEquals(4, it.size());
+      assertEquals(3, it.query(null, "b").size());
+
+      // Delete a node, check that size and queries change
+      assertTrue(it.discard(ad));
+      assertEquals(3, it.size());
+      assertEquals(2, it.query(null, "b").size());
+
+      // Delete the node again, no-op
+      assertFalse(it.discard(ad));
+      assertEquals(3, it.size());
+
+      // Re-add an equivalent node. Check new id, and queries work
+      int ad2 = it.add("a", "d", 3);
+      assertFalse(ad == ad2);
+      assertEquals(4, it.size());
+      assertEquals(3, it.query(null, "b").size());
+
+      // Remove items from node with multiple values
+      assertTrue(it.discard(ac1));
+      assertEquals(3, it.size());
+      assertEquals(2, it.query(null, "b").size());
+      assertFalse(it.discard(ac1));
+
+      assertTrue(it.discard(ac2));
+      assertEquals(2, it.size());
+      assertEquals(1, it.query(null, "b").size());
+      assertFalse(it.discard(ac2));
+    }
+  }
+
+  public static class TestMisc {
+    @Test
+    public void testNullStringCompare() {
+      assertEquals(IntervalTree.nullStringCompare(null, null), 0);
+      assertEquals(IntervalTree.nullStringCompare(null, "a"), 1);
+      assertEquals(IntervalTree.nullStringCompare("a", null), -1);
+      assertEquals(IntervalTree.nullStringCompare("a", "a"), 0);
+      assertEquals(IntervalTree.nullStringCompare("b", "a"), 1);
+      assertEquals(IntervalTree.nullStringCompare("a", "b"), -1);
+    }
+  }
+}

--- a/java/src/test/java/com/anaconda/skein/TestIntervalTree.java
+++ b/java/src/test/java/com/anaconda/skein/TestIntervalTree.java
@@ -11,7 +11,7 @@ import org.junit.runners.Suite;
 
 @RunWith(Suite.class)
 @Suite.SuiteClasses({TestIntervalTree.TestQuery.class,
-                     TestIntervalTree.TestDiscard.class,
+                     TestIntervalTree.TestRemove.class,
                      TestIntervalTree.TestMisc.class})
 public class TestIntervalTree {
   public static class TestQuery {
@@ -51,6 +51,7 @@ public class TestIntervalTree {
       assertEquals(it.size(), 0);
 
       assertEquals(0, it.query(null, null).size());
+      assertEquals(0, it.query("a").size());
     }
 
     @Test
@@ -82,25 +83,36 @@ public class TestIntervalTree {
     public void testQueryBoundsRight() {
       assertEquals(numItems, it.size());
 
-      assertEquals(4, it.query("aa", "b").size());
-      assertEquals(4, it.query("cc", "d").size());
-      assertEquals(1, it.query("gg", "h").size());
+      assertEquals(6, it.query("aa", "b").size());
+      assertEquals(6, it.query("cc", "d").size());
+      assertEquals(2, it.query("gg", "h").size());
       assertEquals(1, it.query("ii", null).size());
+    }
+
+    @Test
+    public void testQuerySingleTarget() {
+      assertEquals(numItems, it.size());
+
+      assertEquals(4, it.query("a").size());
+      assertEquals(4, it.query("aa").size());
+      assertEquals(6, it.query("b").size());
+      assertEquals(2, it.query("f").size());
+      assertEquals(1, it.query("g").size());
     }
   }
 
-  public static class TestDiscard {
+  public static class TestRemove {
     @Test
-    public void testDiscardNonExistant() {
+    public void testRemoveNonExistant() {
       IntervalTree<Integer> it = new IntervalTree<Integer>();
 
       assertEquals(it.size(), 0);
-      assertFalse(it.discard(100));
+      assertFalse(it.remove(100));
       assertEquals(it.size(), 0);
     }
 
     @Test
-    public void testDiscard() {
+    public void testRemove() {
       IntervalTree<Integer> it = new IntervalTree<Integer>();
 
       assertEquals(0, it.size());
@@ -114,12 +126,12 @@ public class TestIntervalTree {
       assertEquals(3, it.query(null, "b").size());
 
       // Delete a node, check that size and queries change
-      assertTrue(it.discard(ad));
+      assertTrue(it.remove(ad));
       assertEquals(3, it.size());
       assertEquals(2, it.query(null, "b").size());
 
       // Delete the node again, no-op
-      assertFalse(it.discard(ad));
+      assertFalse(it.remove(ad));
       assertEquals(3, it.size());
 
       // Re-add an equivalent node. Check new id, and queries work
@@ -129,15 +141,15 @@ public class TestIntervalTree {
       assertEquals(3, it.query(null, "b").size());
 
       // Remove items from node with multiple values
-      assertTrue(it.discard(ac1));
+      assertTrue(it.remove(ac1));
       assertEquals(3, it.size());
       assertEquals(2, it.query(null, "b").size());
-      assertFalse(it.discard(ac1));
+      assertFalse(it.remove(ac1));
 
-      assertTrue(it.discard(ac2));
+      assertTrue(it.remove(ac2));
       assertEquals(2, it.size());
       assertEquals(1, it.query(null, "b").size());
-      assertFalse(it.discard(ac2));
+      assertFalse(it.remove(ac2));
     }
   }
 

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -1,10 +1,10 @@
+from . import kv
 from .core import Client, ApplicationClient, Security
 from .exceptions import (SkeinError, SkeinConfigurationError, ConnectionError,
                          DaemonNotRunningError, ApplicationNotRunningError,
                          DaemonError, ApplicationError)
 from .model import (ApplicationSpec, Service, File, Resources, FileType,
                     FileVisibility)
-from .kv import ops
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -4,6 +4,7 @@ from .exceptions import (SkeinError, SkeinConfigurationError, ConnectionError,
                          DaemonError, ApplicationError)
 from .model import (ApplicationSpec, Service, File, Resources, FileType,
                     FileVisibility)
+from .kv import ops
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/skein/compatibility.py
+++ b/skein/compatibility.py
@@ -10,6 +10,7 @@ if PY2:
     import os
     import types
     from urlparse import urlparse, urlsplit  # noqa
+    from Queue import Queue  # noqa
     unicode = unicode  # noqa
     string = basestring  # noqa
     integer = (int, long)  # noqa
@@ -41,6 +42,7 @@ if PY2:
 else:
     from urllib.parse import urlparse, urlsplit  # noqa
     from os import makedirs  # noqa
+    from queue import Queue  # noqa
     unicode = str
     string = str
     integer = int

--- a/skein/compatibility.py
+++ b/skein/compatibility.py
@@ -10,7 +10,7 @@ if PY2:
     import os
     import types
     from urlparse import urlparse, urlsplit  # noqa
-    from Queue import Queue  # noqa
+    from Queue import Queue, Empty  # noqa
     unicode = unicode  # noqa
     string = basestring  # noqa
     integer = (int, long)  # noqa
@@ -42,7 +42,7 @@ if PY2:
 else:
     from urllib.parse import urlparse, urlsplit  # noqa
     from os import makedirs  # noqa
-    from queue import Queue  # noqa
+    from queue import Queue, Empty  # noqa
     unicode = str
     string = str
     integer = int

--- a/skein/compatibility.py
+++ b/skein/compatibility.py
@@ -8,6 +8,7 @@ PY3 = not PY2
 
 if PY2:
     import os
+    import types
     from urlparse import urlparse, urlsplit  # noqa
     unicode = unicode  # noqa
     string = basestring  # noqa
@@ -34,6 +35,9 @@ if PY2:
     def write_stdout_bytes(b):
         sys.stdout.write(b)
 
+    def bind_method(cls, name, func):
+        setattr(cls, name, types.MethodType(func, None, cls))
+
 else:
     from urllib.parse import urlparse, urlsplit  # noqa
     from os import makedirs  # noqa
@@ -48,6 +52,9 @@ else:
 
     def write_stdout_bytes(b):
         sys.stdout.buffer.write(b)
+
+    def bind_method(cls, name, func):
+        setattr(cls, name, func)
 
 
 def with_metaclass(meta):

--- a/skein/compatibility.py
+++ b/skein/compatibility.py
@@ -27,6 +27,13 @@ if PY2:
         except OSError:
             if not exist_ok or not os.path.isdir(name):
                 raise
+
+    def read_stdin_bytes():
+        return sys.stdin.read()
+
+    def write_stdout_bytes(b):
+        sys.stdout.write(b)
+
 else:
     from urllib.parse import urlparse, urlsplit  # noqa
     from os import makedirs  # noqa
@@ -35,6 +42,12 @@ else:
     integer = int
 
     UTC = datetime.timezone.utc
+
+    def read_stdin_bytes():
+        return sys.stdin.buffer.read()
+
+    def write_stdout_bytes(b):
+        sys.stdout.buffer.write(b)
 
 
 def with_metaclass(meta):

--- a/skein/compatibility.py
+++ b/skein/compatibility.py
@@ -10,7 +10,7 @@ if PY2:
     import os
     import types
     from urlparse import urlparse, urlsplit  # noqa
-    from Queue import Queue, Empty  # noqa
+    from Queue import Queue  # noqa
     unicode = unicode  # noqa
     string = basestring  # noqa
     integer = (int, long)  # noqa
@@ -42,7 +42,7 @@ if PY2:
 else:
     from urllib.parse import urlparse, urlsplit  # noqa
     from os import makedirs  # noqa
-    from queue import Queue, Empty  # noqa
+    from queue import Queue  # noqa
     unicode = str
     string = str
     integer = int

--- a/skein/core.py
+++ b/skein/core.py
@@ -566,6 +566,9 @@ class KeyValueStore(MutableMapping):
         """Return the whole key-value store as a dictionary"""
         return dict(self._client._call('keyvalueGetAll', proto.Empty()).items)
 
+    def _keys(self):
+        return list(self._client._call('keyvalueListAll', proto.Empty()).keys)
+
     def _get(self, key=None, wait=False):
         req = proto.GetKeyRequest(key=key, wait=wait)
         resp = self._client._call('keyvalueGetKey', req)
@@ -586,10 +589,10 @@ class KeyValueStore(MutableMapping):
         self._client._call('keyvalueDelKey', proto.DelKeyRequest(key=key))
 
     def __iter__(self):
-        return iter(self.to_dict())
+        return iter(self._keys())
 
     def __len__(self):
-        return len(self.to_dict())
+        return len(self._keys())
 
 
 class ApplicationClient(_ClientBase):
@@ -640,13 +643,14 @@ class ApplicationClient(_ClientBase):
         Used by applications to coordinate configuration and global state.
 
         This implements the standard MutableMapping interface, along with the
-        ability to "wait" for keys to be set.
+        ability to "wait" for keys to be set. Keys are strings, with values as
+        bytes.
 
         Examples
         --------
-        >>> app_client.kv['foo'] = 'bar'
+        >>> app_client.kv['foo'] = b'bar'
         >>> app_client.kv['foo']
-        'bar'
+        b'bar'
         >>> del app_client.kv['foo']
         >>> 'foo' in app_client.kv
         False

--- a/skein/core.py
+++ b/skein/core.py
@@ -272,6 +272,7 @@ class _ClientBase(object):
         elif code == grpc.StatusCode.NOT_FOUND:
             raise context.KeyError(exc.details())
         elif code in (grpc.StatusCode.INVALID_ARGUMENT,
+                      grpc.StatusCode.FAILED_PRECONDITION,
                       grpc.StatusCode.ALREADY_EXISTS):
             raise context.ValueError(exc.details())
         else:

--- a/skein/exceptions.py
+++ b/skein/exceptions.py
@@ -4,7 +4,7 @@ import warnings
 import sys
 from contextlib import contextmanager
 
-from .compatibility import PY2
+from .compatibility import PY2, bind_method
 
 __all__ = ('FileExistsError',    # py2 compat
            'FileNotFoundError',  # py2 compat
@@ -74,9 +74,6 @@ class _Context(object):
     def __init__(self):
         self.is_cli = False
 
-    def info(self, msg):
-        print(msg)
-
     def warn(self, msg):
         if self.is_cli:
             print(msg + "\n", file=sys.stderr)
@@ -98,11 +95,7 @@ class _Context(object):
         def wrap(self, msg):
             return typ2(msg) if self.is_cli else typ(msg)
 
-        if PY2:
-            import types
-            setattr(cls, name, types.MethodType(wrap, None, cls))
-        else:
-            setattr(cls, name, wrap)
+        bind_method(cls, name, wrap)
 
 
 for exc in [ValueError, KeyError, TypeError, FileExistsError,

--- a/skein/exceptions.py
+++ b/skein/exceptions.py
@@ -11,6 +11,7 @@ __all__ = ('FileExistsError',    # py2 compat
            'SkeinError',
            'SkeinConfigurationError',
            'ConnectionError',
+           'TimeoutError',
            'DaemonNotRunningError',
            'ApplicationNotRunningError',
            'DaemonError',
@@ -21,6 +22,9 @@ if PY2:
     class _ConnectionError(OSError):
         pass
 
+    class _TimeoutError(OSError):
+        pass
+
     class FileExistsError(OSError):
         pass
 
@@ -29,6 +33,7 @@ if PY2:
 
 else:
     _ConnectionError = ConnectionError  # noqa
+    _TimeoutError = TimeoutError  # noqa
     FileExistsError = FileExistsError
     FileNotFoundError = FileNotFoundError
 
@@ -43,6 +48,10 @@ class SkeinConfigurationError(SkeinError, FileNotFoundError):
 
 class ConnectionError(SkeinError, _ConnectionError):
     """Failed to connect to the daemon or application master"""
+
+
+class TimeoutError(SkeinError, _TimeoutError):
+    """Request to daemon or application master timed out"""
 
 
 class DaemonNotRunningError(ConnectionError):

--- a/skein/kv.py
+++ b/skein/kv.py
@@ -1,0 +1,403 @@
+from __future__ import absolute_import, print_function, division
+
+from collections import namedtuple, MutableMapping, OrderedDict
+
+from . import proto
+from .objects import Base, Enum
+from .utils import implements
+
+
+__all__ = ('ResultType',
+           'get_range',
+           'get',
+           'delete_range',
+           'delete',
+           'put',
+           'GetRangeResponse',
+           'DeleteRangeResponse',
+           'PutResponse')
+
+
+def _next_key(prefix):
+    b = bytearray(prefix.encode('utf-8'))
+    b[-1] += 1
+    return bytes(b).decode('utf-8')
+
+
+class ResultType(Enum):
+    """Enum of Result Types for get_range.
+
+    Attributes
+    ----------
+    ITEMS : ResultType
+        Both keys and values are returned for the selection.
+    KEYS : ResultType
+        Only keys are returned for the selection.
+    NONE : ResultType
+        Neither keys or values are returned for the selection.
+    """
+    _values = ('ITEMS',
+               'KEYS',
+               'NONE')
+    _extra_mappings = {None: 'NONE'}
+
+
+class get_range(Base):
+    """A request to get a range of keys.
+
+    Parameters
+    ----------
+    start : str, optional
+        The lower bound of the key range, inclusive. If not provided no lower
+        bound will be used.
+    end : str, optional
+        The upper bound of the key range, exclusive. If not provided, no upper
+        bound will be used.
+    limit : int, optional
+        If provided, only ``limit`` results will be returned.
+    result_type : ResultType, optional
+        Determines the result type. One of:
+        - 'items': Both keys and values are returned for the selection
+        - 'keys': Only keys are returned
+        - 'none': Neither keys or items are returned, ``results`` is None.
+    """
+    __slots__ = ('start', 'end', 'limit', '_result_type')
+    _params = ('start', 'end', 'limit', 'result_type')
+
+    def __init__(self, start=None, end=None, limit=None, result_type='items'):
+        self.start = start
+        self.end = end
+        self.limit = limit
+        self.result_type = result_type
+
+        self._validate()
+
+    def _validate(self):
+        self._check_is_type('start', str, nullable=True)
+        self._check_is_type('end', str, nullable=True)
+        self._check_is_bounded_int('limit', 1, nullable=True)
+        self._check_is_type('result_type', ResultType)
+
+    @property
+    def result_type(self):
+        return self._result_type
+
+    @result_type.setter
+    def result_type(self, val):
+        self._result_type = ResultType(val)
+
+    def __repr__(self):
+        return 'get_range<start=%r, end=%r>' % (self.start, self.end)
+
+    @classmethod
+    @implements(Base.from_protobuf)
+    def from_protobuf(cls, obj):
+        return cls(start=obj.range_start,
+                   end=obj.range_end,
+                   limit=obj.limit or None,
+                   result_type=obj.result_type)
+
+    @implements(Base.to_protobuf)
+    def to_protobuf(self):
+        self._validate()
+        return proto.GetRangeRequest(range_start=self.start,
+                                     range_end=self.end,
+                                     limit=self.limit,
+                                     result_type=str(self.result_type))
+
+
+def get(key):
+    """A request for a single key.
+
+    Parameters
+    ----------
+    key : str, optional
+        The key to get.
+
+    Returns
+    -------
+    req : get_range
+        The get_range request.
+    """
+    return get_range(start=key, end=key + '\x00')
+
+
+class delete_range(Base):
+    """A request to delete a range of keys.
+
+    Parameters
+    ----------
+    start : str, optional
+        The lower bound of the key range, inclusive. If not provided no lower
+        bound will be used.
+    end : str, optional
+        The upper bound of the key range, exclusive. If not provided, no upper
+        bound will be used.
+    result_type : ResultType, optional
+        Determines the result type. One of:
+        - 'none': Neither keys or items are returned, ``results`` is None.
+        - 'items': Both keys and values are returned for the previous items
+          in the selection.
+        - 'keys': Only keys are returned for the previous items in the selection.
+    """
+    __slots__ = ('start', 'end', '_result_type')
+    _params = ('start', 'end', 'result_type')
+
+    def __init__(self, start=None, end=None, result_type='items'):
+        self.start = start
+        self.end = end
+        self.result_type = result_type
+
+        self._validate()
+
+    def _validate(self):
+        self._check_is_type('start', str, nullable=True)
+        self._check_is_type('end', str, nullable=True)
+        self._check_is_type('result_type', ResultType)
+
+    @property
+    def result_type(self):
+        return self._result_type
+
+    @result_type.setter
+    def result_type(self, val):
+        self._result_type = ResultType(val)
+
+    def __repr__(self):
+        return 'delete_range<start=%r, end=%r>' % (self.start, self.end)
+
+    @classmethod
+    @implements(Base.from_protobuf)
+    def from_protobuf(cls, obj):
+        return cls(start=obj.range_start,
+                   end=obj.range_end,
+                   result_type=obj.result_type)
+
+    @implements(Base.to_protobuf)
+    def to_protobuf(self):
+        self._validate()
+        return proto.DeleteRangeRequest(range_start=self.start,
+                                        range_end=self.end,
+                                        result_type=str(self.result_type))
+
+
+def delete(key):
+    """A request to delete a single key.
+
+    Parameters
+    ----------
+    key : str, optional
+        The key to delete.
+
+    Returns
+    -------
+    req : delete_range
+        The delete_range request.
+    """
+    return delete_range(start=key, end=key + '\x00')
+
+
+class put(Base):
+    """A request to put a key-value pair.
+
+    Parameters
+    ----------
+    key : str
+        The key to put.
+    value : bytes
+        The value to put.
+    return_previous : bool, optional
+        If True, the previous key-value pair will be returned. Default is False.
+    """
+    __slots__ = ('key', 'value', 'return_previous')
+
+    def __init__(self, key, value, return_previous=False):
+        self.key = key
+        self.value = value
+        self.return_previous = return_previous
+
+        self._validate()
+
+    def _validate(self):
+        self._check_is_type('key', str)
+        self._check_is_type('value', bytes)
+        self._check_is_type('return_previous', bool)
+
+    def __repr__(self):
+        return 'put<key=%r>' % self.key
+
+
+class GetRangeResponse(namedtuple('GetRangeResponse',
+                                  ['count', 'result_type', 'results'])):
+    """Response from a ``get_range`` action.
+
+    Attributes
+    ----------
+    count : int
+        The total number of key-value pairs that matched the query.  If a limit
+        was specified in the query, this number may be greater than the number
+        of items actually returned.
+    result_type : ResultType
+        The type of the result.
+    result : OrderedDict, list, or None
+        The type of this attribute depends on ``result_type``:
+        - ``ResultType.ITEMS`` (default): an OrderedDict of key-value pairs
+          matching the query, sorted by key.
+        - ``ResultType.KEYS``: a list of keys, sorted by key.
+        - ``ResultType.NONE``: None.
+    """
+    pass
+
+
+class DeleteRangeResponse(namedtuple('DeleteRangeResponse',
+                                     ['count', 'result_type', 'results'])):
+    """Response from a ``del_range`` action.
+
+    Attributes
+    ----------
+    count : int
+        The total number of key-value pairs that were deleted.
+    result_type : ResultType
+        The type of the result.
+    previous : None or OrderedDict
+        The type of this attribute depends on ``result_type``:
+        - By default this is None
+        - If ``prev_kv`` was ``True``, this is an OrderedDict of the deleted
+          key-value pairs, sorted by key.
+    """
+    pass
+
+
+class PutResponse(namedtuple('PutResponse', ['previous'])):
+    """Response from a ``put`` action.
+
+    Attributes
+    ----------
+    previous : None or tuple
+        The type of this attribute depends on the ``put`` action:
+        - By default this is None
+        - If ``return_previous`` was ``True``, this is an tuple of
+        ``(key, previous_value)``.
+    """
+    pass
+
+
+class KeyValueStore(MutableMapping):
+    """The Skein Key-Value store.
+
+    Used by applications to coordinate configuration and global state.
+
+    This implements the standard MutableMapping interface, along with the
+    ability to "wait" for keys to be set.
+    """
+    def __init__(self, client):
+        self._client = client
+
+    def __iter__(self):
+        req = proto.GetRangeRequest(result_type='KEYS')
+        resp = self._client._call('GetRange', req)
+        return (kv.key for kv in resp.kv)
+
+    def __len__(self):
+        req = proto.GetRangeRequest(result_type='NONE')
+        resp = self._client._call('GetRange', req)
+        return resp.count
+
+    def __setitem__(self, key, value):
+        req = proto.PutRequest(kv=proto.KeyValue(key=key, value=value))
+        self._client._call('Put', req)
+
+    @staticmethod
+    def _check_slice(k):
+        if k.step is not None:
+            raise TypeError("Slicing with step not supported")
+
+    @staticmethod
+    def _check_limit(limit):
+        if limit is not None and limit <= 0:
+            raise ValueError("limit must be > 0")
+
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            self._check_slice(key)
+            req = proto.GetRangeRequest(range_start=key.start,
+                                        range_end=key.stop)
+            resp = self._client._call('GetRange', req)
+            return OrderedDict((kv.key, kv.value) for kv in resp.kv)
+        else:
+            req = proto.GetRangeRequest(range_start=key,
+                                        range_end=key + '\x00')
+            resp = self._client._call('GetRange', req)
+            if resp.count == 0:
+                raise KeyError(key)
+            return resp.kv[0].value
+
+    def __delitem__(self, key):
+        if isinstance(key, slice):
+            self._check_slice(key)
+            req = proto.DeleteRangeRequest(range_start=key.start,
+                                           range_end=key.stop)
+            self._client._call('DeleteRange', req)
+        else:
+            req = proto.DeleteRangeRequest(range_start=key,
+                                           range_end=key + '\x00')
+            resp = self._client._call('DeleteRange', req)
+            if resp.count == 0:
+                raise KeyError(key)
+
+    def clear(self):
+        req = proto.DeleteRangeRequest()
+        self._cleint.call('DeleteRange', req)
+
+    def pop(self, key, default=None):
+        req = proto.DeleteRangeRequest(range_start=key,
+                                       range_end=key + '\x00',
+                                       result_type='ITEMS')
+        resp = self._client._call('DeleteRange', req)
+        if resp.count == 0:
+            if default is None:
+                raise KeyError(key)
+            return default
+        return resp.prev_kv[0].value
+
+    def get_prefix(self, prefix, limit=None):
+        """Get all key-value pairs whose keys start with ``prefix``.
+
+        Parameters
+        ----------
+        prefix : str
+            The key prefix.
+        limit : int, optional
+            The maximum number of key-value pairs to return. Default is all
+            matching pairs.
+
+        Returns
+        -------
+        submap : OrderedDict
+            A sub-map of the key-value store, containing all matching key-value
+            pairs, sorted by key.
+        """
+        self._check_limit(limit)
+        req = proto.GetRangeRequest(range_start=prefix,
+                                    range_end=_next_key(prefix),
+                                    limit=limit)
+        resp = self._client._call('GetRange', req)
+        return OrderedDict((kv.key, kv.value) for kv in resp.kv)
+
+    def delete_prefix(self, prefix):
+        """Delete all key-value pairs whose keys start with ``prefix``.
+
+        Parameters
+        ----------
+        prefix : str
+            The key prefix.
+
+        Returns
+        -------
+        count : int
+            The number of items deleted
+        """
+        req = proto.DeleteRangeRequest(range_start=prefix,
+                                       range_end=_next_key(prefix))
+        resp = self._client._call('DeleteRange', req)
+        return resp.count

--- a/skein/kv.py
+++ b/skein/kv.py
@@ -361,7 +361,7 @@ class pop_prefix(_GetOrPopPrefix):
         is False.
     """
     __slots__ = ('prefix', 'return_owner')
-    _proto = _proto.GetRangeRequest
+    _proto = _proto.DeleteRangeRequest
     _rpc = 'DeleteRange'
 
 
@@ -686,7 +686,7 @@ class swap(_PutOrSwap):
     """
     __slots__ = ('key', 'value', 'return_owner', '_owner', '_owner_proto')
     _params = ('key', 'value', 'owner', 'return_owner')
-    _return_previous = False
+    _return_previous = True
 
     def __init__(self, key, value=_no_change, owner=_no_change,
                  return_owner=False):
@@ -701,6 +701,8 @@ class swap(_PutOrSwap):
                 % (self.key, self.value, self.owner, self.return_owner))
 
     def _build_result(self, result):
-        if self.return_owner:
-            return ValueOwnerPair._from_kv_protobuf(result.previous)
-        return result.previous.value
+        if result.HasField("previous"):
+            if self.return_owner:
+                return ValueOwnerPair._from_kv_protobuf(result.previous)
+            return result.previous.value
+        return ValueOwnerPair(None, None) if self.return_owner else None

--- a/skein/model.py
+++ b/skein/model.py
@@ -477,7 +477,7 @@ class ApplicationSpec(Specification):
         application as failed. Note that this only considers failures of the
         application master during startup. Default is 1.
     """
-    __slots__ = ('name', 'queue', 'services', 'tags', 'max_attempts')
+    __slots__ = ('services', 'name', 'queue', 'tags', 'max_attempts')
     _protobuf_cls = _proto.ApplicationSpec
 
     def __init__(self, services=required, name='skein', queue='default', tags=None,

--- a/skein/objects.py
+++ b/skein/objects.py
@@ -61,17 +61,11 @@ class EnumMeta(type):
 
 class Enum(with_metaclass(EnumMeta)):
     _values = ()
-    _extra_mappings = None
     __slots__ = ('_value',)
 
     def __new__(cls, x):
         if isinstance(x, cls):
             return x
-        if cls._extra_mappings is not None:
-            try:
-                x = cls._extra_mappings[x]
-            except (TypeError, KeyError):
-                pass
         if not isinstance(x, string):
             raise TypeError("Expected 'str' or %r" % cls.__name__)
         x = ensure_unicode(x).upper()

--- a/skein/objects.py
+++ b/skein/objects.py
@@ -22,11 +22,11 @@ def typename(cls):
 # These are all used semantically the same, but have different reprs
 # to show up nicely when used interactively/in docs.
 required = type('required', (object,),
-                {'__repr__': lambda s: 'required'})()
+                dict.fromkeys(['__repr__', '__reduce__'],
+                              lambda s: 'required'))()
 no_change = type('no_change', (object,),
-                 {'__repr__': lambda s: 'no_change'})()
-no_default = type('no_default', (object,),
-                  {'__repr__': lambda s: 'no_default'})()
+                 dict.fromkeys(['__repr__', '__reduce__'],
+                               lambda s: 'no_change'))()
 
 
 def is_list_of(x, typ):
@@ -118,6 +118,10 @@ def _convert(x, method, *args):
         return x
 
 
+def rebuild(cls, params):
+    return cls(**params)
+
+
 class Base(object):
     """Base class for typed objects"""
     __slots__ = ()
@@ -129,6 +133,10 @@ class Base(object):
 
     def __ne__(self, other):
         return not (self == other)
+
+    def __reduce__(self):
+        params = {p: getattr(self, p) for p in self._get_params()}
+        return (rebuild, (type(self), params))
 
     @classmethod
     def _get_params(cls):

--- a/skein/objects.py
+++ b/skein/objects.py
@@ -1,0 +1,232 @@
+from __future__ import absolute_import, print_function, division
+
+import json
+from datetime import datetime
+
+import yaml
+
+from .compatibility import with_metaclass, string, integer
+from .exceptions import context
+from .utils import format_list, ensure_unicode, datetime_to_millis
+
+
+def typename(cls):
+    if cls is string:
+        return 'string'
+    elif cls is integer:
+        return 'integer'
+    return cls.__name__
+
+
+required = type('required', (object,),
+                {'__repr__': lambda s: 'required'})()
+
+
+def is_list_of(x, typ):
+    return isinstance(x, list) and all(isinstance(i, typ) for i in x)
+
+
+def is_set_of(x, typ):
+    return isinstance(x, set) and all(isinstance(i, typ) for i in x)
+
+
+def is_dict_of(x, ktyp, vtyp):
+    return (isinstance(x, dict) and
+            all(isinstance(k, ktyp) for k in x.keys()) and
+            all(isinstance(v, vtyp) for v in x.values()))
+
+
+class EnumMeta(type):
+    def __init__(cls, name, parents, dct):
+        cls._values = tuple(ensure_unicode(v) for v in cls._values)
+        for name in cls._values:
+            out = object.__new__(cls)
+            out._value = name
+            setattr(cls, name, out)
+        return super(EnumMeta, cls).__init__(name, parents, dct)
+
+    def __iter__(cls):
+        return (getattr(cls, f) for f in cls._values)
+
+    def __len__(cls):
+        return len(cls._values)
+
+
+class Enum(with_metaclass(EnumMeta)):
+    _values = ()
+    _extra_mappings = None
+    __slots__ = ('_value',)
+
+    def __new__(cls, x):
+        if isinstance(x, cls):
+            return x
+        if cls._extra_mappings is not None:
+            try:
+                x = cls._extra_mappings[x]
+            except (TypeError, KeyError):
+                pass
+        if not isinstance(x, string):
+            raise TypeError("Expected 'str' or %r" % cls.__name__)
+        x = ensure_unicode(x).upper()
+        if x not in cls._values:
+            raise context.ValueError("%r must be in %r"
+                                     % (cls.__name__, cls._values))
+        return getattr(cls, x)
+
+    def __reduce__(self):
+        return (getattr, (type(self), self._value))
+
+    def __repr__(self):
+        return '%s.%s' % (type(self).__name__, self._value)
+
+    def __str__(self):
+        return self._value
+
+    def __eq__(self, other):
+        return (self is other or
+                (isinstance(other, string) and self._value == other.upper()))
+
+    def __hash__(self):
+        return hash(self._value)
+
+    @classmethod
+    def values(cls):
+        """The constants of this enum type, in the order they are declared."""
+        return cls._values
+
+
+def _convert(x, method, *args):
+    if hasattr(x, method):
+        return getattr(x, method)(*args)
+    typ = type(x)
+    if typ in (list, set, tuple):
+        return [_convert(i, method, *args) for i in x]
+    elif typ is dict:
+        return {k: _convert(v, method, *args) for k, v in x.items()}
+    elif typ is datetime:
+        return datetime_to_millis(x)
+    elif isinstance(x, Enum):
+        return str(x)
+    else:
+        return x
+
+
+class Base(object):
+    """Base class for typed objects"""
+    __slots__ = ()
+
+    def __eq__(self, other):
+        return (type(self) == type(other) and
+                all(getattr(self, k) == getattr(other, k)
+                    for k in self._get_params()))
+
+    def __ne__(self, other):
+        return not (self == other)
+
+    @classmethod
+    def _get_params(cls):
+        return getattr(cls, '_params', cls.__slots__)
+
+    def _assign_required(self, name, val):
+        if val is required:
+            raise context.TypeError("parameter %r is required but wasn't "
+                                    "provided" % name)
+        setattr(self, name, val)
+
+    @classmethod
+    def _check_keys(cls, obj, keys=None):
+        keys = keys or cls._get_params()
+        if not isinstance(obj, dict):
+            raise context.TypeError("Expected mapping for %r" % cls.__name__)
+        extra = set(obj).difference(keys)
+        if extra:
+            raise context.ValueError("Unknown extra keys for %s:\n"
+                                     "%s" % (cls.__name__, format_list(extra)))
+
+    def _check_is_type(self, field, type, nullable=False):
+        val = getattr(self, field)
+        if not (isinstance(val, type) or (nullable and val is None)):
+            if nullable:
+                msg = "%s must be a %s, or None"
+            else:
+                msg = "%s must be a %s"
+            raise context.TypeError(msg % (field, typename(type)))
+
+    def _check_is_set_of(self, field, type):
+        if not is_set_of(getattr(self, field), type):
+            msg = "%s must be a set of %s"
+            raise context.TypeError(msg % (field, typename(type)))
+
+    def _check_is_list_of(self, field, type):
+        if not is_list_of(getattr(self, field), type):
+            msg = "%s must be a list of %s"
+            raise context.TypeError(msg % (field, typename(type)))
+
+    def _check_is_dict_of(self, field, key, val):
+        if not is_dict_of(getattr(self, field), key, val):
+            msg = "%s must be a dict of %s -> %s"
+            raise context.TypeError(msg % (field, typename(key), typename(val)))
+
+    def _check_is_bounded_int(self, field, min=0, nullable=False):
+        x = getattr(self, field)
+        self._check_is_type(field, integer, nullable=nullable)
+        if x is not None and x < min:
+            raise context.ValueError("%s must be >= %d" % (field, min))
+
+    @classmethod
+    def from_protobuf(cls, msg):
+        """Create an instance from a protobuf message."""
+        if not isinstance(msg, cls._protobuf_cls):
+            raise TypeError("Expected message of type "
+                            "%r" % cls._protobuf_cls.__name__)
+        kwargs = {k: getattr(msg, k) for k in cls._get_params()}
+        return cls(**kwargs)
+
+    def to_protobuf(self):
+        """Convert object to a protobuf message"""
+        self._validate()
+        kwargs = {k: _convert(getattr(self, k), 'to_protobuf')
+                  for k in self._get_params()}
+        return self._protobuf_cls(**kwargs)
+
+
+class Specification(Base):
+    """Base class for objects that are part of the specification"""
+    @classmethod
+    def from_dict(cls, obj):
+        """Create an instance from a dict.
+
+        Keys in the dict should match parameter names"""
+        cls._check_keys(obj)
+        return cls(**obj)
+
+    @classmethod
+    def from_json(cls, b):
+        """Create an instance from a json string.
+
+        Keys in the json object should match parameter names"""
+        return cls.from_dict(json.loads(b))
+
+    @classmethod
+    def from_yaml(cls, b):
+        """Create an instance from a yaml string."""
+        return cls.from_dict(yaml.safe_load(b))
+
+    def to_dict(self, skip_nulls=True):
+        """Convert object to a dict"""
+        self._validate()
+        out = {}
+        for k in self._get_params():
+            val = getattr(self, k)
+            if not skip_nulls or val is not None:
+                out[k] = _convert(val, 'to_dict', skip_nulls)
+        return out
+
+    def to_json(self, skip_nulls=True):
+        """Convert object to a json string"""
+        return json.dumps(self.to_dict(skip_nulls=skip_nulls))
+
+    def to_yaml(self, skip_nulls=True):
+        """Convert object to a yaml string"""
+        return yaml.safe_dump(self.to_dict(skip_nulls=skip_nulls),
+                              default_flow_style=False)

--- a/skein/objects.py
+++ b/skein/objects.py
@@ -18,8 +18,15 @@ def typename(cls):
     return cls.__name__
 
 
+# constants used to detect no parameter passed to keyword argument
+# These are all used semantically the same, but have different reprs
+# to show up nicely when used interactively/in docs.
 required = type('required', (object,),
                 {'__repr__': lambda s: 'required'})()
+no_change = type('no_change', (object,),
+                 {'__repr__': lambda s: 'no_change'})()
+no_default = type('no_default', (object,),
+                  {'__repr__': lambda s: 'no_default'})()
 
 
 def is_list_of(x, typ):
@@ -147,9 +154,9 @@ class Base(object):
         val = getattr(self, field)
         if not (isinstance(val, type) or (nullable and val is None)):
             if nullable:
-                msg = "%s must be a %s, or None"
+                msg = '%s must be a %s, or None'
             else:
-                msg = "%s must be a %s"
+                msg = '%s must be a %s'
             raise context.TypeError(msg % (field, typename(type)))
 
     def _check_is_set_of(self, field, type):
@@ -173,6 +180,8 @@ class Base(object):
         if x is not None and x < min:
             raise context.ValueError("%s must be >= %d" % (field, min))
 
+
+class ProtobufMessage(Base):
     @classmethod
     def from_protobuf(cls, msg):
         """Create an instance from a protobuf message."""
@@ -190,7 +199,7 @@ class Base(object):
         return self._protobuf_cls(**kwargs)
 
 
-class Specification(Base):
+class Specification(ProtobufMessage):
     """Base class for objects that are part of the specification"""
     @classmethod
     def from_dict(cls, obj):

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -3,7 +3,10 @@ from __future__ import absolute_import
 from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
                         Service, ApplicationSpec, ResourceUsageReport,
                         ApplicationReport, Application, ApplicationsRequest,
-                        Url, GetKeyRequest, SetKeyRequest, DelKeyRequest,
-                        ContainersRequest, Container, ContainerInstance,
+                        Url, ContainersRequest, Container, ContainerInstance,
                         ScaleRequest, ShutdownRequest)
+from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
+                        PutRequest, PutResponse,
+                        DeleteRangeRequest, DeleteRangeResponse,
+                        KeyValue)
 from .skein_pb2_grpc import DaemonStub, MasterStub

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -6,7 +6,7 @@ from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
                         Url, ContainersRequest, Container, ContainerInstance,
                         ScaleRequest, ShutdownRequest)
 from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
-                        PutRequest, PutResponse,
+                        PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,
                         KeyValue)
 from .skein_pb2_grpc import DaemonStub, MasterStub

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -11,5 +11,5 @@ from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         KeyValue, Condition, OpRequest, OpResponse,
                         TransactionRequest, TransactionResponse,
                         WatchRequest, WatchCreateRequest, WatchCancelRequest,
-                        WatchResponse, Event)
+                        WatchResponse)
 from .skein_pb2_grpc import DaemonStub, MasterStub

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -8,5 +8,5 @@ from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
 from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,
-                        KeyValue)
+                        KeyValue, Condition)
 from .skein_pb2_grpc import DaemonStub, MasterStub

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -8,5 +8,6 @@ from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
 from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,
-                        KeyValue, Condition)
+                        KeyValue, Condition, OpRequest, OpResponse,
+                        TransactionRequest, TransactionResponse)
 from .skein_pb2_grpc import DaemonStub, MasterStub

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -9,5 +9,7 @@ from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,
                         KeyValue, Condition, OpRequest, OpResponse,
-                        TransactionRequest, TransactionResponse)
+                        TransactionRequest, TransactionResponse,
+                        WatchRequest, WatchCreateRequest, WatchCancelRequest,
+                        WatchResponse, Event)
 from .skein_pb2_grpc import DaemonStub, MasterStub

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -330,7 +330,8 @@ def test_cli_kv(global_client, capfdbinary):
         run_command('kv get %s --key fizz' % app.id, error=True)
         out, err = capfdbinary.readouterr()
         assert not out
-        assert b"Error: Key 'fizz' is not set\n" == err
+        assert ((b"Error: Key %s is not set\n"
+                 % (b"u'fizz'" if PY2 else b"'fizz'")) == err)
 
         # Kill application
         run_command('application kill %s' % app.id)

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -81,7 +81,8 @@ def global_client(kinit, tmpdir_factory):
                           'kv',
                           'kv get',
                           'kv put',
-                          'kv del'])
+                          'kv del',
+                          'kv ls'])
 def test_cli_help(command, capsys):
     run_command(command + ' -h')
 

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -1,10 +1,7 @@
 from __future__ import print_function, division, absolute_import
 
 import os
-import time
 import weakref
-from collections import MutableMapping
-from threading import Thread
 
 import pytest
 
@@ -137,54 +134,6 @@ def test_simple_app(client):
 
     finished_apps = client.get_applications(states=['finished'])
     assert app.id in {a.id for a in finished_apps}
-
-
-def test_key_value(client):
-    with run_application(client) as app:
-        assert isinstance(app.kv, MutableMapping)
-        assert app.kv is app.kv
-
-        assert dict(app.kv) == {}
-
-        app.kv['foo'] = b'bar'
-        assert app.kv['foo'] == b'bar'
-
-        assert dict(app.kv) == {'foo': b'bar'}
-        assert app.kv.to_dict() == {'foo': b'bar'}
-        assert len(app.kv) == 1
-
-        del app.kv['foo']
-        assert app.kv.to_dict() == {}
-        assert len(app.kv) == 0
-
-        with pytest.raises(KeyError):
-            app.kv['fizz']
-
-        with pytest.raises(TypeError):
-            app.kv[1] = 'foo'
-
-        with pytest.raises(TypeError):
-            app.kv['foo'] = u'bar'
-
-        with pytest.raises(TypeError):
-            app.kv['foo'] = 1
-
-        def set_foo():
-            time.sleep(0.5)
-            app.kv['foo'] = b'baz'
-
-        setter = Thread(target=set_foo)
-        setter.daemon = True
-        setter.start()
-
-        val = app.kv.wait('foo')
-        assert val == b'baz'
-
-        # Get immediately for set keys
-        val2 = app.kv.wait('foo')
-        assert val2 == b'baz'
-
-        app.shutdown()
 
 
 def test_dynamic_containers(client):

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -146,11 +146,11 @@ def test_key_value(client):
 
         assert dict(app.kv) == {}
 
-        app.kv['foo'] = 'bar'
-        assert app.kv['foo'] == 'bar'
+        app.kv['foo'] = b'bar'
+        assert app.kv['foo'] == b'bar'
 
-        assert dict(app.kv) == {'foo': 'bar'}
-        assert app.kv.to_dict() == {'foo': 'bar'}
+        assert dict(app.kv) == {'foo': b'bar'}
+        assert app.kv.to_dict() == {'foo': b'bar'}
         assert len(app.kv) == 1
 
         del app.kv['foo']
@@ -164,22 +164,25 @@ def test_key_value(client):
             app.kv[1] = 'foo'
 
         with pytest.raises(TypeError):
+            app.kv['foo'] = u'bar'
+
+        with pytest.raises(TypeError):
             app.kv['foo'] = 1
 
         def set_foo():
             time.sleep(0.5)
-            app.kv['foo'] = 'baz'
+            app.kv['foo'] = b'baz'
 
         setter = Thread(target=set_foo)
         setter.daemon = True
         setter.start()
 
         val = app.kv.wait('foo')
-        assert val == 'baz'
+        assert val == b'baz'
 
         # Get immediately for set keys
         val2 = app.kv.wait('foo')
-        assert val2 == 'baz'
+        assert val2 == b'baz'
 
         app.shutdown()
 

--- a/skein/test/test_kv.py
+++ b/skein/test/test_kv.py
@@ -1,0 +1,197 @@
+from __future__ import print_function, division, absolute_import
+
+import copy
+from collections import MutableMapping
+
+import pytest
+
+import skein
+from skein.test.conftest import run_application
+
+
+def test_clean_tab_completion_kv_namespace():
+    public = [n for n in dir(skein.kv) if not n.startswith('_')]
+    assert set(public) == set(skein.kv.__all__)
+
+
+@pytest.mark.parametrize('cls', [skein.kv.count, skein.kv.list_keys])
+def test_count_and_list_keys_types(cls):
+    x1 = cls()
+    assert repr(x1) == ("%s(range_start=None, range_end=None)" % cls.__name__)
+    x2 = cls(prefix='foo')
+    assert repr(x2) == ("%s(prefix='foo')" % cls.__name__)
+    x3 = cls(range_start='foo')
+    assert repr(x3) == ("%s(range_start='foo', range_end=None)" % cls.__name__)
+    for x in [x1, x2, x3]:
+        assert x == copy.deepcopy(x)
+    assert x1 != x2
+
+    with pytest.raises(AttributeError):
+        x1.foobar = 1
+
+    with pytest.raises(ValueError):
+        cls(prefix='foo', range_start='bar')
+
+    for k in ['prefix', 'range_start', 'range_end']:
+        with pytest.raises(TypeError):
+            cls(**{k: b'bad type'})
+
+
+@pytest.mark.parametrize('cls', [skein.kv.contains, skein.kv.discard])
+def test_contains_and_discard_types(cls):
+    x = cls('foo')
+    assert repr(x) == ("%s('foo')" % cls.__name__)
+    assert x == copy.deepcopy(x)
+    assert x != cls('bar')
+
+    with pytest.raises(AttributeError):
+        x.foobar = 1
+
+    with pytest.raises(TypeError):
+        cls(b'foo')
+
+
+@pytest.mark.parametrize('cls', [skein.kv.get, skein.kv.pop])
+def test_get_and_pop_types(cls):
+    name = cls.__name__
+    x1 = cls('key')
+    assert repr(x1) == ("%s('key', default=None, return_owner=False)" % name)
+    x2 = cls('key', default=b'bar', return_owner=True)
+    assert repr(x2) == ("%s('key', default=b'bar', return_owner=True)" % name)
+    for x in [x1, x2]:
+        assert x == copy.deepcopy(x)
+    assert x1 != x2
+
+    with pytest.raises(AttributeError):
+        x1.foobar = 1
+
+    with pytest.raises(TypeError):
+        cls('foo', default='bar')
+
+    with pytest.raises(TypeError):
+        cls('foo', return_owner=None)
+
+    with pytest.raises(TypeError):
+        cls(b'foo')
+
+
+@pytest.mark.parametrize('cls,kw', [(skein.kv.get_prefix, 'return_owner'),
+                                    (skein.kv.pop_prefix, 'return_owner'),
+                                    (skein.kv.discard_prefix, 'return_keys')])
+def test_prefix_types(cls, kw):
+    name = cls.__name__
+    x1 = cls('key')
+    assert repr(x1) == ("%s('key', %s=False)" % (name, kw))
+    x2 = cls('key', **{kw: True})
+    assert repr(x2) == ("%s('key', %s=True)" % (name, kw))
+    for x in [x1, x2]:
+        assert x == copy.deepcopy(x)
+    assert x1 != x2
+
+    with pytest.raises(AttributeError):
+        x1.foobar = 1
+
+    with pytest.raises(TypeError):
+        cls(b'foo')
+
+    with pytest.raises(TypeError):
+        cls('foo', **{kw: None})
+
+
+@pytest.mark.parametrize('cls,kw', [(skein.kv.get_range, 'return_owner'),
+                                    (skein.kv.pop_range, 'return_owner'),
+                                    (skein.kv.discard_range, 'return_keys')])
+def test_range_types(cls, kw):
+    name = cls.__name__
+    x1 = cls()
+    assert repr(x1) == ("%s(start=None, end=None, %s=False)" % (name, kw))
+    x2 = cls(start='key', end='bar', **{kw: True})
+    assert repr(x2) == ("%s(start='key', end='bar', %s=True)" % (name, kw))
+    for x in [x1, x2]:
+        assert x == copy.deepcopy(x)
+    assert x1 != x2
+
+    with pytest.raises(AttributeError):
+        x1.foobar = 1
+
+    for k in ['start', 'end', kw]:
+        with pytest.raises(TypeError):
+            cls(**{k: b'bad type'})
+
+
+@pytest.mark.parametrize('cls,has_return_owner',
+                         [(skein.kv.put, False), (skein.kv.swap, True)])
+def test_put_and_swap_types(cls, has_return_owner):
+    name = cls.__name__
+    if has_return_owner:
+        extra = ', return_owner=False'
+    else:
+        extra = ''
+    x1 = cls('foo', value=b'bar')
+    assert repr(x1) == ("%s('foo', value=b'bar', owner=no_change%s)"
+                        % (name, extra))
+    x2 = cls('foo', owner='container_1')
+    assert repr(x2) == ("%s('foo', value=no_change, owner='container_1'%s)"
+                        % (name, extra))
+    x3 = cls('foo', owner=None)
+    assert repr(x3) == ("%s('foo', value=no_change, owner=None%s)"
+                        % (name, extra))
+    for x in [x1, x2, x3]:
+        assert x == copy.deepcopy(x)
+    assert x1 != x2
+
+    with pytest.raises(AttributeError):
+        x1.foobar = 1
+
+    with pytest.raises(ValueError):
+        cls('foo', owner='invalid')
+
+    with pytest.raises(TypeError):
+        cls(b'wrong_type', value=b'bar')
+
+    with pytest.raises(TypeError):
+        cls('foo', owner=b'wrong_type')
+
+    with pytest.raises(ValueError):
+        cls('foo')
+
+
+def test_key_value(client):
+    with run_application(client) as app:
+        assert isinstance(app.kv, MutableMapping)
+        assert app.kv is app.kv
+
+        assert dict(app.kv) == {}
+
+        app.kv['foo'] = b'bar'
+        assert app.kv['foo'] == b'bar'
+
+        assert dict(app.kv) == {'foo': b'bar'}
+        assert len(app.kv) == 1
+        assert 'foo' in app.kv
+        assert 'food' not in app.kv
+
+        del app.kv['foo']
+        assert len(app.kv) == 0
+
+        app.kv.update({'a': b'one', 'b': b'two'})
+        assert len(app.kv) == 2
+        app.kv.clear()
+        assert len(app.kv) == 0
+
+        with pytest.raises(KeyError):
+            del app.kv['foo']
+
+        with pytest.raises(KeyError):
+            app.kv['fizz']
+
+        with pytest.raises(TypeError):
+            app.kv[1] = 'foo'
+
+        with pytest.raises(TypeError):
+            app.kv['foo'] = u'bar'
+
+        with pytest.raises(TypeError):
+            app.kv['foo'] = 1
+
+        app.shutdown()

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -49,33 +49,38 @@ services:
 %s""" % indent(service_spec, 8)
 
 
-def check_basic_methods(obj, obspec2):
+def check_base_methods(obj, obj2):
     # equality
     assert obj == copy.deepcopy(obj)
     assert not (obj != copy.deepcopy(obj))
-    assert obj != obspec2
+    assert obj != obj2
     assert obj != 'incorrect_type'
 
     # smoketest repr
     repr(obj)
+
+    cls = type(obj)
+    proto = obj.to_protobuf()
+    obj2 = cls.from_protobuf(proto)
+    assert obj == obj2
+
+
+def check_specification_methods(obj, obj2):
+    check_base_methods(obj, obj2)
 
     # conversions
     cls = type(obj)
     for skip in [True, False]:
         for method in ['json', 'yaml', 'dict']:
             msg = getattr(obj, 'to_' + method)(skip_nulls=skip)
-            obspec2 = getattr(cls, 'from_' + method)(msg)
-            assert obj == obspec2
-
-    proto = obj.to_protobuf()
-    obspec2 = cls.from_protobuf(proto)
-    assert obj == obspec2
+            obj2 = getattr(cls, 'from_' + method)(msg)
+            assert obj == obj2
 
 
 def test_resources():
     r = Resources(memory=1024, vcores=1)
     r2 = Resources(memory=1024, vcores=2)
-    check_basic_methods(r, r2)
+    check_specification_methods(r, r2)
 
 
 def test_resources_invariants():
@@ -95,7 +100,7 @@ def test_resources_invariants():
 def test_file():
     fil = File(source='/test/path')
     fil2 = File(source='/test/path', size=1024)
-    check_basic_methods(fil, fil2)
+    check_specification_methods(fil, fil2)
 
 
 def test_file_invariants():
@@ -150,7 +155,7 @@ def test_service():
                  files={'file': File(source='/test/path')})
     s2 = Service(resources=r, commands=c,
                  files={'file': File(source='/test/path', size=1024)})
-    check_basic_methods(s1, s2)
+    check_specification_methods(s1, s2)
 
 
 def test_service_invariants():
@@ -202,7 +207,7 @@ def test_application_spec():
                  files={'file': File(source='/test/path', size=1024)})
     spec1 = ApplicationSpec(services={'service': s1})
     spec2 = ApplicationSpec(services={'service': s2})
-    check_basic_methods(spec1, spec2)
+    check_specification_methods(spec1, spec2)
 
 
 def test_application_spec_invariants():
@@ -365,7 +370,7 @@ def test_container():
                    finish_time=None,
                    **kwargs)
 
-    check_basic_methods(c, c2)
+    check_base_methods(c, c2)
 
     assert c.id == "foo_0"
 
@@ -387,7 +392,7 @@ def test_resource_usage_report():
     a = ResourceUsageReport(10, 20, 2, r1, r2, r3)
     b = ResourceUsageReport(11, 20, 2, r1, r2, r3)
 
-    check_basic_methods(a, b)
+    check_base_methods(a, b)
 
 
 def test_application_report():
@@ -424,7 +429,7 @@ def test_application_report():
                           finish_time=finish,
                           **kwargs)
 
-    check_basic_methods(a, b)
+    check_base_methods(a, b)
 
     assert b.runtime == b.finish_time - b.start_time
     before = datetime.datetime.now(UTC)

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -53,6 +53,7 @@ def check_base_methods(obj, obj2):
     # equality
     assert obj == copy.deepcopy(obj)
     assert not (obj != copy.deepcopy(obj))
+    assert obj2 == copy.deepcopy(obj2)
     assert obj != obj2
     assert obj != 'incorrect_type'
 

--- a/skein/test/test_utils.py
+++ b/skein/test/test_utils.py
@@ -2,7 +2,8 @@ from __future__ import absolute_import, print_function, division
 
 from datetime import timedelta
 
-from skein.utils import humanize_timedelta, format_table
+from skein.utils import (humanize_timedelta, format_table,
+                         format_comma_separated_list)
 
 
 def test_humanize_timedelta():
@@ -24,3 +25,10 @@ def test_format_table():
            'pear      green')
     assert res == sol
     assert format_table(['fruit', 'color'], []) == 'FRUIT    COLOR'
+
+
+def test_format_comma_separated_list():
+    assert format_comma_separated_list([]) == ''
+    assert format_comma_separated_list([None]) == 'None'
+    assert format_comma_separated_list([None, False]) == 'None or False'
+    assert format_comma_separated_list([None, False, True]) == 'None, False, or True'

--- a/skein/utils.py
+++ b/skein/utils.py
@@ -15,6 +15,19 @@ def format_list(x):
     return "\n".join("- %s" % s for s in sorted(x))
 
 
+def format_comma_separated_list(x, conjunction='or'):
+    n = len(x)
+    if n == 0:
+        return ''
+    if n == 1:
+        return str(x[0])
+    if n == 2:
+        left, right = x
+        return '%s %s %s' % (left, conjunction, right)
+    left, right = ', '.join(map(str, x[:-1])), x[-1]
+    return '%s, %s %s' % (left, conjunction, right)
+
+
 def humanize_timedelta(td):
     """Pretty-print a timedelta in a human readable format."""
     secs = int(td.total_seconds())

--- a/skein/utils.py
+++ b/skein/utils.py
@@ -1,6 +1,8 @@
 from __future__ import print_function, division, absolute_import
 
-from .compatibility import unicode
+from datetime import datetime, timedelta
+
+from .compatibility import unicode, UTC
 
 
 def ensure_unicode(x):
@@ -23,6 +25,27 @@ def humanize_timedelta(td):
     if mins:
         return '%dm' % mins
     return '%ds' % secs
+
+
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+
+def datetime_from_millis(x):
+    if x is None or x == 0:
+        return None
+    return _EPOCH + timedelta(milliseconds=x)
+
+
+def datetime_to_millis(x):
+    return int((x - _EPOCH).total_seconds() * 1000)
+
+
+def runtime(start_time, finish_time):
+    if start_time is None:
+        return timedelta(0)
+    if finish_time is None:
+        return datetime.now(UTC) - start_time
+    return finish_time - start_time
 
 
 def format_table(columns, rows):


### PR DESCRIPTION
This is a rewrite of the key-value store to enable more concurrency primitives. The core design is borrowed from etcd, with changes made to simplify things where possible.

Todo:
- [x] Move the key-value store value type to bytes
- [x] Implement core operations (`get_range`, `delete_range`, `put`, and variations of these)
- [x] Implement conditionals (`contains`, `missing`, `comparison`, and `value`/`owner` expressions)
- [x] Implement transactions, which allow for atomic operation support
- [x] Implement the `app.kv` mutable mapping api with the above
- [x] Implement watch operations, which allow for getting change notifications

Fixes #33, Fixes #35.