### PR TITLE
Implemented ``Base.__ne__``

### DIFF
--- a/skein/model.py
+++ b/skein/model.py
@@ -255,6 +255,9 @@ class Base(object):
                 all(getattr(self, k) == getattr(other, k)
                     for k in self._get_params()))
 
+    def __ne__(self, other):
+        return not (self == other)
+
     @classmethod
     def _get_params(cls):
         return getattr(cls, '_params', cls.__slots__)

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -52,6 +52,7 @@ services:
 def check_basic_methods(obj, obspec2):
     # equality
     assert obj == copy.deepcopy(obj)
+    assert not (obj != copy.deepcopy(obj))
     assert obj != obspec2
     assert obj != 'incorrect_type'
 


### PR DESCRIPTION
Previously on Python 2.X the instances were compared using reference
(as opposed to structural) equality. This can be easily verified by
running the following:

    >>> class A:
    ...     def __init__(self, a):
    ...         self.a = a
    ...     def __eq__(self, other):
    ...         return self.a == other.a
    ...
    >>> A(42) == A(42)
    True
    >>> A(42) != A(42)
    True

Note that on Python 3.X the output is True/False as expected.