### PR TITLE
Add runtime properties mapping 

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -170,9 +170,6 @@ Exceptions
 .. autoexception:: SkeinError
     :show-inheritance:
 
-.. autoexception:: SkeinConfigurationError
-    :show-inheritance:
-
 .. autoexception:: ConnectionError
     :show-inheritance:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -27,6 +27,12 @@ Application Client
     :inherited-members:
 
 
+Runtime Properties
+------------------
+
+.. autodata:: properties
+
+
 Key Value Store
 ---------------
 

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -1,8 +1,8 @@
 from . import kv
 from .core import Client, ApplicationClient, Security, properties
-from .exceptions import (SkeinError, SkeinConfigurationError, ConnectionError,
-                         DaemonNotRunningError, ApplicationNotRunningError,
-                         DaemonError, ApplicationError)
+from .exceptions import (SkeinError, ConnectionError, DaemonNotRunningError,
+                         ApplicationNotRunningError, DaemonError,
+                         ApplicationError)
 from .model import (ApplicationSpec, Service, File, Resources, FileType,
                     FileVisibility)
 

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -1,5 +1,5 @@
 from . import kv
-from .core import Client, ApplicationClient, Security
+from .core import Client, ApplicationClient, Security, properties
 from .exceptions import (SkeinError, SkeinConfigurationError, ConnectionError,
                          DaemonNotRunningError, ApplicationNotRunningError,
                          DaemonError, ApplicationError)

--- a/skein/compatibility.py
+++ b/skein/compatibility.py
@@ -8,6 +8,7 @@ PY3 = not PY2
 
 if PY2:
     import os
+    import re
     import types
     from urlparse import urlparse, urlsplit  # noqa
     from Queue import Queue  # noqa
@@ -39,6 +40,11 @@ if PY2:
     def bind_method(cls, name, func):
         setattr(cls, name, types.MethodType(func, None, cls))
 
+    _name_re = re.compile(r"[a-zA-Z_][a-zA-Z0-9_]*$")
+
+    def isidentifier(s):
+        return bool(_name_re.match(s))
+
 else:
     from urllib.parse import urlparse, urlsplit  # noqa
     from os import makedirs  # noqa
@@ -57,6 +63,9 @@ else:
 
     def bind_method(cls, name, func):
         setattr(cls, name, func)
+
+    def isidentifier(s):
+        return s.isidentifier()
 
 
 def with_metaclass(meta):

--- a/skein/exceptions.py
+++ b/skein/exceptions.py
@@ -9,7 +9,6 @@ from .compatibility import PY2, bind_method
 __all__ = ('FileExistsError',    # py2 compat
            'FileNotFoundError',  # py2 compat
            'SkeinError',
-           'SkeinConfigurationError',
            'ConnectionError',
            'TimeoutError',
            'DaemonNotRunningError',
@@ -40,10 +39,6 @@ else:
 
 class SkeinError(Exception):
     """Base class for Skein specific exceptions"""
-
-
-class SkeinConfigurationError(SkeinError, FileNotFoundError):
-    """Skein configuration was not found"""
 
 
 class ConnectionError(SkeinError, _ConnectionError):

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -13,12 +13,12 @@ import skein
 @contextmanager
 def set_skein_config(tmpdir):
     tmpdir = str(tmpdir)
-    old = skein.core.CONFIG_DIR
+    old = skein.properties.config_dir
     try:
-        skein.core.CONFIG_DIR = tmpdir
+        skein.properties._mapping['config_dir'] = tmpdir
         yield tmpdir
     finally:
-        skein.core.CONFIG_DIR = old
+        skein.properties._mapping['config_dir'] = old
 
 
 @pytest.fixture

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -11,6 +11,25 @@ from skein.test.conftest import (run_application, wait_for_containers,
                                  wait_for_success, get_logs)
 
 
+def test_properties():
+    assert len(skein.properties) == len(dict(skein.properties))
+    assert skein.properties.config_dir == skein.properties['config_dir']
+    assert 'config_dir' in dir(skein.properties)
+    assert 'missing' not in skein.properties
+
+    with pytest.raises(AttributeError):
+        skein.properties.missing
+
+    with pytest.raises(AttributeError):
+        skein.properties.missing = 1
+
+    with pytest.raises(KeyError):
+        skein.properties['missing']
+
+    with pytest.raises(TypeError):
+        skein.properties['missing'] = 1
+
+
 def test_security(tmpdir):
     path = str(tmpdir)
     s1 = skein.Security.from_new_directory(path)
@@ -104,6 +123,12 @@ def test_client_closed_when_reference_dropped(security, kinit):
     del client
     assert ref() is None
     assert not pid_exists(pid)
+
+
+def test_application_client_from_current_errors():
+    with pytest.raises(ValueError) as exc:
+        skein.ApplicationClient.from_current()
+    assert str(exc.value) == "Not running inside a container"
 
 
 def test_simple_app(client):


### PR DESCRIPTION
Add `properties` object, which stores immutable runtime configuration properties. Exposes things like `container_id` or `application_id` (for when running inside a container).

Also delete unnecessary `SkeinConfigurationProperties` exception (unused since previous release).