### PR TITLE
Ensure consistent ownership state

### DIFF
--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -885,6 +885,10 @@ public class ApplicationMaster {
                       .sendMsg(watchId, wrBuilder.setWatchId(watchId).build());
                 }
               }
+            } else {
+              LOG.warn("Key '" + key
+                       + "' already deleted, but wasn't removed from "
+                       + "owned-keys set of service " + name);
             }
           }
           container.clearOwnedKeys();
@@ -1178,6 +1182,15 @@ public class ApplicationMaster {
           }
 
           // Do deletion
+          // Clear owners first before deleting
+          for (Map.Entry<String, Msg.KeyValue.Builder> entry : selection.entrySet()) {
+            Msg.KeyValue.Builder value = entry.getValue();
+            if (value.hasOwner()) {
+              services.get(value.getOwner().getServiceName())
+                      .removeOwnedKey(value.getOwner().getInstance(),
+                                      entry.getKey());
+            }
+          }
           selection.clear();
         }
       }


### PR DESCRIPTION
Previously the following steps would result in inconsistent ownership
state in the key-value store:

- Create a key
- Assign an owner to that key
- Delete the key
- Create the key again, without an owner

At this point the key-value store would say the key was unowned, but the
``ServiceTracker`` would still have the key in its set of owned keys.

We now test for this case, and owned keys from their service trackers
upon deletion.