### PR TITLE
Doc edits

### DIFF
--- a/docs/source/distributing-files.rst
+++ b/docs/source/distributing-files.rst
@@ -2,16 +2,17 @@ Distributing Files
 ==================
 
 Most applications require some number of files (executables, configuration,
-scripts, etc...) to run. When deploying these applications on YARN you have a
-few options:
+scripts, etc...) to run. When deploying these applications on YARN you have
+two options depending on the kind of access you want to assume:
 
-1. Install the files on every node in the cluster. This usually requires a
-   cluster administrator, and is often only done for things like commonly used
-   libraries. For example, you might install Python and common libraries on
-   every node, but not your application code.
+1. **IT Permissions**: Install the files on every node in the cluster. This
+   usually requires a cluster administrator, and is often only done for things
+   like commonly used libraries. For example, you might install Python and
+   common libraries on every node, but not your application code.
 
-2. Distribute the files to the executing containers as part of the application.
-   This is the common approach, and does not require administrator privileges.
+2. **User Permissions**: Distribute the files to the executing containers as
+   part of the application.  This is the common approach, and does not require
+   administrator privileges.
 
 Both options have their place, and can be mixed in a single application. Below
 we discuss the second option in detail.
@@ -93,7 +94,7 @@ The File Distribution Process
 When an application launches, the following process occurs:
 
 1. An application staging directory is created in the user's home directory on
-   default filesystem (typically HDFS). The path for this is the format
+   the default filesystem (typically HDFS). The path for this is the format
    ``~/.skein/{application id}``.
 
 2. The missing fields for each file in the application specification are
@@ -114,16 +115,17 @@ When an application launches, the following process occurs:
 5. When the application completes, the staging directory is deleted.
 
 
-Using Conda-Pack to Distribute Python Environments
---------------------------------------------------
+Distribute Python Environments With Conda-Pack
+----------------------------------------------
 
 When deploying Python applications, one needs to figure out how to distribute
-any library dependencies. If Python and the required libraries are already
-installed on every node (option 1 above), you can use the local Python and
-avoid this problem completely. If they aren't, then one way to distribute them
-is to use the `conda package manager <https://conda.io/docs/>`__ to create a
-Python environment, and `conda-pack <https://conda.github.io/conda-pack/>`__ to
-package that environment for distribution.
+any library dependencies. If Python and all required libraries are already
+installed on every node (option 1 above), then you can use the local Python and
+avoid this problem completely. However if these libraries aren't installed by
+IT, then one way that users can distributed libraries themselves is to use the
+`conda package manager <https://conda.io/docs/>`__ to create a Python
+environment, and `conda-pack <https://conda.github.io/conda-pack/>`__ to
+package that environment for distribution with YARN (or other services).
 
 ``conda-pack`` is a tool for taking a conda environment and creating an archive
 of it in a way that (most) absolute paths in any libraries or scripts are

--- a/docs/source/distributing-files.rst
+++ b/docs/source/distributing-files.rst
@@ -121,11 +121,11 @@ Distribute Python Environments With Conda-Pack
 When deploying Python applications, one needs to figure out how to distribute
 any library dependencies. If Python and all required libraries are already
 installed on every node (option 1 above), then you can use the local Python and
-avoid this problem completely. However if these libraries aren't installed by
-IT, then one way that users can distributed libraries themselves is to use the
-`conda package manager <https://conda.io/docs/>`__ to create a Python
-environment, and `conda-pack <https://conda.github.io/conda-pack/>`__ to
-package that environment for distribution with YARN (or other services).
+avoid this problem completely. Otherwise, one way that users can distribute
+libraries themselves is to use the `conda package manager
+<https://conda.io/docs/>`__ to create a Python environment, and `conda-pack
+<https://conda.github.io/conda-pack/>`__ to package that environment for
+distribution with YARN (or other services).
 
 ``conda-pack`` is a tool for taking a conda environment and creating an archive
 of it in a way that (most) absolute paths in any libraries or scripts are

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,13 +13,13 @@ Skein
     1. *A quantity of yarn, thread, or the like, put up together, after it is taken from the reel.*
 
 
-Skein is a simple library and cli for deploying applications on `Apache YARN
+Skein is a simple library and command line interface (CLI) for deploying
+applications on `Apache YARN
 <https://hadoop.apache.org/docs/current/hadoop-yarn/hadoop-yarn-site/YARN.html>`_.
 While YARN has many features that make it powerful for developing resilient
 applications, these features also can make it difficult for developers to use.
 
-Skein aims to be easy to use, providing just as much YARN as your project
-needs.
+Skein is easy to use, providing just as much YARN as your project needs.
 
 Installation
 ------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -85,17 +85,44 @@ Where the contents of ``payload.txt`` is:
 
 Walking through this specification:
 
-- The application name is specified as ``hello_world``, and the will be
-  deployed in the YARN queue ``default``.
+- The application name is specified as ``hello_world``, and will be deployed in
+  the YARN queue ``default``.
+
+  .. code-block:: yaml
+
+     name: hello_world
+     queue: default
 
 - The application starts a single service ``my_service`` on a container using 1
   virtual core and 128 MB of memory.
 
+  .. code-block:: yaml
+
+     services:
+       my_service:
+         resources:
+           vcores: 1
+           memory: 128
+
+
 - The file ``payload.txt`` is distributed with the application, and is named
   ``payload.txt`` both locally and on the running container.
 
+  .. code-block:: yaml
+
+     files:
+       payload.txt: payload.txt
+
 - The service runs a few Shell commands. These will be run in order, stopping
   on the first failure, and all outputs logged in the container logs.
+
+  .. code-block:: yaml
+
+     commands:
+       - echo "Sleeping for 60 seconds"
+       - sleep 60
+       - cat payload.txt
+       - echo "Stopping service"
 
 
 Submit the Application

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -110,19 +110,21 @@ Walking through this specification:
 
   .. code-block:: yaml
 
-     files:
-       payload.txt: payload.txt
+     ...
+         files:
+           payload.txt: payload.txt
 
 - The service runs a few Shell commands. These will be run in order, stopping
   on the first failure, and all outputs logged in the container logs.
 
   .. code-block:: yaml
 
-     commands:
-       - echo "Sleeping for 60 seconds"
-       - sleep 60
-       - cat payload.txt
-       - echo "Stopping service"
+     ...
+         commands:
+           - echo "Sleeping for 60 seconds"
+           - sleep 60
+           - cat payload.txt
+           - echo "Stopping service"
 
 
 Submit the Application


### PR DESCRIPTION
I went through and made some small modifications.  I tried to break them out a bit to facilitate piece-wise rejection/acceptance.


Some other thoughts that I didn't implement:

-  Should the quickstart end with other next steps, like perhaps pointers to the CLI reference or the YARN documentation for additional operations?
-  Specification Components.  The last item, `services`, should possibly be given more weight.  It might make sense to say that this is where most of the application is defined.