### PR TITLE
Added support for ViewFs

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -173,6 +173,13 @@
 
     <dependency>
       <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-core</artifactId>
+      <version>${hadoopVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-client</artifactId>
       <version>${hadoopVersion}</version>
       <scope>provided</scope>

--- a/java/src/main/java/com/anaconda/skein/Daemon.java
+++ b/java/src/main/java/com/anaconda/skein/Daemon.java
@@ -271,7 +271,7 @@ public class Daemon {
               credentials,
               ObjectArrays.concat(
                       new Path(defaultFs.getUri()),
-                      spec.getNameNodes().toArray(new Path[0])),
+                      spec.getFileSystems().toArray(new Path[0])),
               conf);
 
       DataOutputBuffer dob = new DataOutputBuffer();

--- a/java/src/main/java/com/anaconda/skein/Daemon.java
+++ b/java/src/main/java/com/anaconda/skein/Daemon.java
@@ -1,5 +1,7 @@
 package com.anaconda.skein;
 
+import com.google.common.collect.ObjectArrays;
+
 import io.grpc.Server;
 import io.grpc.Status;
 import io.grpc.StatusRuntimeException;
@@ -17,10 +19,11 @@ import org.apache.hadoop.fs.FileUtil;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.DataOutputBuffer;
+import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
@@ -263,14 +266,14 @@ public class Daemon {
     // Add security tokens as needed
     ByteBuffer fsTokens = null;
     if (UserGroupInformation.isSecurityEnabled()) {
-      Credentials credentials = new Credentials();
-      String tokenRenewer = conf.get(YarnConfiguration.RM_PRINCIPAL);
-      if (tokenRenewer == null || tokenRenewer.length() == 0) {
-        throw new IOException("Can't determine Yarn ResourceManager Kerberos "
-                              + "principal for the RM to use as renewer");
-      }
+      Credentials credentials = UserGroupInformation.getLoginUser().getCredentials();
+      TokenCache.obtainTokensForNamenodes(
+              credentials,
+              ObjectArrays.concat(
+                      new Path(defaultFs.getUri()),
+                      spec.getNameNodes().toArray(new Path[0])),
+              conf);
 
-      defaultFs.addDelegationTokens(tokenRenewer, credentials);
       DataOutputBuffer dob = new DataOutputBuffer();
       credentials.writeTokenStorageToStream(dob);
       fsTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -1,5 +1,6 @@
 package com.anaconda.skein;
 
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.NodeId;
@@ -106,16 +107,19 @@ public class Model {
     private String queue;
     private int maxAttempts;
     private Set<String> tags;
+    private List<Path> nameNodes;
     private Map<String, Service> services;
 
     public ApplicationSpec() {}
 
     public ApplicationSpec(String name, String queue, int maxAttempts,
-                           Set<String> tags, Map<String, Service> services) {
+                           Set<String> tags, List<Path> nameNodes,
+                           Map<String, Service> services) {
       this.name = name;
       this.queue = queue;
       this.maxAttempts = maxAttempts;
       this.tags = tags;
+      this.nameNodes = nameNodes;
       this.services = services;
     }
 
@@ -139,6 +143,9 @@ public class Model {
 
     public void setTags(Set<String> tags) { this.tags = tags; }
     public Set<String> getTags() { return this.tags; }
+
+    public void setNameNodes(List<Path> nameNodes) { this.nameNodes = nameNodes; }
+    public List<Path> getNameNodes() { return this.nameNodes; }
 
     public void setServices(Map<String, Service> services) { this.services = services; }
     public Map<String, Service> getServices() { return services; }

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -107,19 +107,19 @@ public class Model {
     private String queue;
     private int maxAttempts;
     private Set<String> tags;
-    private List<Path> nameNodes;
+    private List<Path> fileSystems;
     private Map<String, Service> services;
 
     public ApplicationSpec() {}
 
     public ApplicationSpec(String name, String queue, int maxAttempts,
-                           Set<String> tags, List<Path> nameNodes,
+                           Set<String> tags, List<Path> fileSystems,
                            Map<String, Service> services) {
       this.name = name;
       this.queue = queue;
       this.maxAttempts = maxAttempts;
       this.tags = tags;
-      this.nameNodes = nameNodes;
+      this.fileSystems = fileSystems;
       this.services = services;
     }
 
@@ -129,6 +129,7 @@ public class Model {
               + "queue: " + queue + ", "
               + "maxAttempts: " + maxAttempts + ", "
               + "tags: " + tags + ", "
+              + "fileSystems" + fileSystems + ", "
               + "services: " + services + ">");
     }
 
@@ -144,8 +145,10 @@ public class Model {
     public void setTags(Set<String> tags) { this.tags = tags; }
     public Set<String> getTags() { return this.tags; }
 
-    public void setNameNodes(List<Path> nameNodes) { this.nameNodes = nameNodes; }
-    public List<Path> getNameNodes() { return this.nameNodes; }
+    public void setFileSystems(List<Path> fileSystems) {
+      this.fileSystems = fileSystems;
+    }
+    public List<Path> getFileSystems() { return this.fileSystems; }
 
     public void setServices(Map<String, Service> services) { this.services = services; }
     public Map<String, Service> getServices() { return services; }
@@ -155,6 +158,7 @@ public class Model {
       throwIfNull(queue, "queue");
       throwIfLessThan(maxAttempts, 1, "maxAttempts");
       throwIfNull(tags, "tags");
+      throwIfNull(fileSystems, "fileSystems");
       throwIfNull(services, "services");
       if (services.size() == 0) {
         throw new IllegalArgumentException("There must be at least one service");

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -1,6 +1,5 @@
 package com.anaconda.skein;
 
-import com.google.common.base.Function;
 import com.google.common.base.Functions;
 import com.google.common.collect.Lists;
 
@@ -305,7 +304,7 @@ public class MsgUtils {
         .setQueue(spec.getQueue())
         .setMaxAttempts(spec.getMaxAttempts())
         .addAllTags(spec.getTags())
-        .addAllNameNodes(Lists.transform(spec.getNameNodes(), Functions.toStringFunction()));
+        .addAllFileSystems(Lists.transform(spec.getFileSystems(), Functions.toStringFunction()));
 
     for (Map.Entry<String, Model.Service> entry : spec.getServices().entrySet()) {
       builder.putServices(entry.getKey(), writeService(entry.getValue()));
@@ -318,16 +317,16 @@ public class MsgUtils {
     for (Map.Entry<String, Msg.Service> entry : spec.getServicesMap().entrySet()) {
       services.put(entry.getKey(), readService(entry.getValue()));
     }
-    final List<Path> nameNodes = Lists.transform(
-        spec.getNameNodesList(),
-        new Function<String, Path>() {
-          public Path apply(String uri) { return new Path(uri); }
-        });
+
+    final List<Path> fileSystems = new ArrayList<Path>();
+    for (int i = 0; i < spec.getFileSystemsCount(); i++) {
+      fileSystems.add(new Path(spec.getFileSystems(i)));
+    }
     return new Model.ApplicationSpec(spec.getName(),
                                      spec.getQueue(),
                                      spec.getMaxAttempts(),
                                      new HashSet<String>(spec.getTagsList()),
-                                     nameNodes,
+                                     fileSystems,
                                      services);
   }
 

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -1,5 +1,10 @@
 package com.anaconda.skein;
 
+import com.google.common.base.Function;
+import com.google.common.base.Functions;
+import com.google.common.collect.Lists;
+
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationResourceUsageReport;
 import org.apache.hadoop.yarn.api.records.ContainerId;
@@ -299,7 +304,8 @@ public class MsgUtils {
         .setName(spec.getName())
         .setQueue(spec.getQueue())
         .setMaxAttempts(spec.getMaxAttempts())
-        .addAllTags(spec.getTags());
+        .addAllTags(spec.getTags())
+        .addAllNameNodes(Lists.transform(spec.getNameNodes(), Functions.toStringFunction()));
 
     for (Map.Entry<String, Model.Service> entry : spec.getServices().entrySet()) {
       builder.putServices(entry.getKey(), writeService(entry.getValue()));
@@ -312,10 +318,16 @@ public class MsgUtils {
     for (Map.Entry<String, Msg.Service> entry : spec.getServicesMap().entrySet()) {
       services.put(entry.getKey(), readService(entry.getValue()));
     }
+    final List<Path> nameNodes = Lists.transform(
+        spec.getNameNodesList(),
+        new Function<String, Path>() {
+          public Path apply(String uri) { return new Path(uri); }
+        });
     return new Model.ApplicationSpec(spec.getName(),
                                      spec.getQueue(),
                                      spec.getMaxAttempts(),
                                      new HashSet<String>(spec.getTagsList()),
+                                     nameNodes,
                                      services);
   }
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -87,7 +87,8 @@ message ApplicationSpec {
   string queue = 2;
   int32 max_attempts = 3;
   repeated string tags = 4;
-  map<string, Service> services = 5;
+  repeated string name_nodes = 5;
+  map<string, Service> services = 6;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -87,7 +87,7 @@ message ApplicationSpec {
   string queue = 2;
   int32 max_attempts = 3;
   repeated string tags = 4;
-  repeated string name_nodes = 5;
+  repeated string file_systems = 5;
   map<string, Service> services = 6;
 }
 

--- a/setup.py
+++ b/setup.py
@@ -65,6 +65,8 @@ class build_proto(Command):
 class build_java(Command):
     description = "build java artifacts"
 
+    user_options = []
+
     def initialize_options(self):
         pass
 

--- a/skein/model.py
+++ b/skein/model.py
@@ -472,20 +472,24 @@ class ApplicationSpec(Specification):
         The queue to submit to. Defaults to the default queue.
     tags : set, optional
         A set of strings to use as tags for this application.
+    name_nodes : list, optional
+        A list of namenode URIs to acquire delegation tokens for.
     max_attempts : int, optional
         The maximum number of submission attempts before marking the
         application as failed. Note that this only considers failures of the
         application master during startup. Default is 1.
     """
-    __slots__ = ('services', 'name', 'queue', 'tags', 'max_attempts')
+    __slots__ = ('services', 'name', 'queue', 'tags', 'name_nodes',
+                 'max_attempts')
     _protobuf_cls = _proto.ApplicationSpec
 
-    def __init__(self, services=required, name='skein', queue='default', tags=None,
-                 max_attempts=1):
+    def __init__(self, services=required, name='skein', queue='default',
+                 tags=None, name_nodes=None, max_attempts=1):
         self._assign_required('services', services)
         self.name = name
         self.queue = queue
         self.tags = set() if tags is None else set(tags)
+        self.name_nodes = [] if name_nodes is None else name_nodes
         self.max_attempts = max_attempts
         self._validate()
 
@@ -497,6 +501,7 @@ class ApplicationSpec(Specification):
         self._check_is_type('name', string)
         self._check_is_type('queue', string)
         self._check_is_set_of('tags', string)
+        self._check_is_list_of('name_nodes', string)
         self._check_is_bounded_int('max_attempts', min=1)
         self._check_is_dict_of('services', string, Service)
         if not self.services:
@@ -536,6 +541,7 @@ class ApplicationSpec(Specification):
         return cls(name=obj.name,
                    queue=obj.queue,
                    tags=set(obj.tags),
+                   name_nodes=list(obj.name_nodes),
                    max_attempts=min(1, obj.max_attempts),
                    services=services)
 

--- a/skein/model.py
+++ b/skein/model.py
@@ -472,24 +472,25 @@ class ApplicationSpec(Specification):
         The queue to submit to. Defaults to the default queue.
     tags : set, optional
         A set of strings to use as tags for this application.
-    name_nodes : list, optional
-        A list of namenode URIs to acquire delegation tokens for.
+    file_systems : list, optional
+        A list of Hadoop file systems to acquire delegation tokens for.
+        A token is always acuired for the ``defaultFS``.
     max_attempts : int, optional
         The maximum number of submission attempts before marking the
         application as failed. Note that this only considers failures of the
         application master during startup. Default is 1.
     """
-    __slots__ = ('services', 'name', 'queue', 'tags', 'name_nodes',
+    __slots__ = ('services', 'name', 'queue', 'tags', 'file_systems',
                  'max_attempts')
     _protobuf_cls = _proto.ApplicationSpec
 
     def __init__(self, services=required, name='skein', queue='default',
-                 tags=None, name_nodes=None, max_attempts=1):
+                 tags=None, file_systems=None, max_attempts=1):
         self._assign_required('services', services)
         self.name = name
         self.queue = queue
         self.tags = set() if tags is None else set(tags)
-        self.name_nodes = [] if name_nodes is None else name_nodes
+        self.file_systems = [] if file_systems is None else file_systems
         self.max_attempts = max_attempts
         self._validate()
 
@@ -501,7 +502,7 @@ class ApplicationSpec(Specification):
         self._check_is_type('name', string)
         self._check_is_type('queue', string)
         self._check_is_set_of('tags', string)
-        self._check_is_list_of('name_nodes', string)
+        self._check_is_list_of('file_systems', string)
         self._check_is_bounded_int('max_attempts', min=1)
         self._check_is_dict_of('services', string, Service)
         if not self.services:
@@ -541,7 +542,7 @@ class ApplicationSpec(Specification):
         return cls(name=obj.name,
                    queue=obj.queue,
                    tags=set(obj.tags),
-                   name_nodes=list(obj.name_nodes),
+                   file_systems=list(obj.file_systems),
                    max_attempts=min(1, obj.max_attempts),
                    services=services)
 

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -268,7 +268,7 @@ def test_file_systems(client):
     spec = skein.ApplicationSpec(name="test_file_systems",
                                  queue="default",
                                  services={'service': service},
-                                 file_systems=["hdfs://master.example.com"])
+                                 file_systems=["hdfs://master.example.com:9000"])
 
     with run_application(client, spec=spec) as app:
         wait_for_success(client, app.id)

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -259,3 +259,16 @@ def test_container_environment(client, has_kerberos_enabled):
     else:
         assert "LOGIN_ID=[yarn]" in logs
         assert "HADOOP_USER_NAME" in logs
+
+
+def test_file_systems(client):
+    commands = ['hdfs dfs -touchz /user/testuser/test_file_systems']
+    service = skein.Service(resources=skein.Resources(memory=124, vcores=1),
+                            commands=commands)
+    spec = skein.ApplicationSpec(name="test_file_systems",
+                                 queue="default",
+                                 services={'service': service},
+                                 file_systems=["hdfs://master.example.com"])
+
+    with run_application(client, spec=spec) as app:
+        wait_for_success(client, app.id)

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -43,7 +43,7 @@ max_attempts: 2
 tags:
     - tag1
     - tag2
-name_nodes:
+file_systems:
     - hdfs://preprod
 
 services:
@@ -285,7 +285,7 @@ def test_application_spec_from_yaml():
     assert spec.name == 'test'
     assert spec.queue == 'default'
     assert spec.tags == {'tag1', 'tag2'}
-    assert spec.name_nodes == ['hdfs://preprod']
+    assert spec.file_systems == ['hdfs://preprod']
     assert spec.max_attempts == 2
     assert isinstance(spec.services, dict)
     assert isinstance(spec.services['service_1'], Service)

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -43,6 +43,8 @@ max_attempts: 2
 tags:
     - tag1
     - tag2
+name_nodes:
+    - hdfs://preprod
 
 services:
     service_1:
@@ -283,6 +285,7 @@ def test_application_spec_from_yaml():
     assert spec.name == 'test'
     assert spec.queue == 'default'
     assert spec.tags == {'tag1', 'tag2'}
+    assert spec.name_nodes == ['hdfs://preprod']
     assert spec.max_attempts == 2
     assert isinstance(spec.services, dict)
     assert isinstance(spec.services['service_1'], Service)


### PR DESCRIPTION
Prior to this commit the Daemon only accquired a delegation token for
defaultFs which did not work well in the presence of federation. Now the
application spec contains a list the namenodes to acquire the delegation
token for in addition to defaultFs. In theory, all tokens should be
automatically renewed by the RM. However, I did not have the occasion
to test this.