### PR TITLE
Fail the app when container is killed for exceeding memory limits

### DIFF
--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -189,6 +189,7 @@ public class Model {
     private String yarnNodeHttpAddress;
     private long startTime;
     private long finishTime;
+    private String exitMessage;
     private ContainerRequest req;
     private Set<String> ownedKeys;
 
@@ -262,6 +263,9 @@ public class Model {
 
     public void setFinishTime(long finishTime) { this.finishTime = finishTime; }
     public long getFinishTime() { return finishTime; }
+
+    public void setExitMessage(String diagnostics) { this.exitMessage = diagnostics; }
+    public String getExitMessage() { return exitMessage; }
 
     public void setContainerRequest(ContainerRequest req) { this.req = req; }
     public ContainerRequest popContainerRequest() {

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -338,6 +338,9 @@ public class MsgUtils {
         .setStartTime(container.getStartTime())
         .setFinishTime(container.getFinishTime());
 
+    if (container.getExitMessage() != null) {
+      builder.setExitMessage(container.getExitMessage());
+    }
     ContainerId containerId = container.getYarnContainerId();
     if (containerId != null) {
       builder.setYarnContainerId(containerId.toString());
@@ -357,6 +360,7 @@ public class MsgUtils {
     out.setYarnContainerId(ContainerId.fromString(container.getYarnContainerId()));
     out.setStartTime(container.getStartTime());
     out.setFinishTime(container.getFinishTime());
+    out.setExitMessage(container.getExitMessage());
     return out;
   }
 }

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -108,6 +108,7 @@ message Container {
   string yarn_node_http_address = 5;
   int64 start_time = 6;
   int64 finish_time = 7;
+  string exit_message = 8;
 }
 
 

--- a/skein/model.py
+++ b/skein/model.py
@@ -822,15 +822,20 @@ class Container(ProtobufMessage):
         The start time, None if container has not started.
     finish_time : datetime
         The finish time, None if container has not finished.
+    exit_message : str
+        The diagnostic exit message for failed containers.
     """
     __slots__ = ('service_name', 'instance', '_state', 'yarn_container_id',
-                 'yarn_node_http_address', 'start_time', 'finish_time')
+                 'yarn_node_http_address', 'start_time', 'finish_time',
+                 'exit_message')
     _params = ('service_name', 'instance', 'state', 'yarn_container_id',
-               'yarn_node_http_address', 'start_time', 'finish_time')
+               'yarn_node_http_address', 'start_time', 'finish_time',
+               'exit_message')
     _protobuf_cls = _proto.Container
 
     def __init__(self, service_name, instance, state, yarn_container_id,
-                 yarn_node_http_address, start_time, finish_time):
+                 yarn_node_http_address, start_time, finish_time,
+                 exit_message):
         self.service_name = service_name
         self.instance = instance
         self.state = state
@@ -838,6 +843,7 @@ class Container(ProtobufMessage):
         self.yarn_node_http_address = yarn_node_http_address
         self.start_time = start_time
         self.finish_time = finish_time
+        self.exit_message = exit_message
 
         self._validate()
 
@@ -861,6 +867,7 @@ class Container(ProtobufMessage):
         self._check_is_type('yarn_node_http_address', string)
         self._check_is_type('start_time', datetime, nullable=True)
         self._check_is_type('finish_time', datetime, nullable=True)
+        self._check_is_type('exit_message', string, nullable=True)
 
     @property
     def id(self):
@@ -894,4 +901,5 @@ class Container(ProtobufMessage):
                    yarn_container_id=obj.yarn_container_id,
                    yarn_node_http_address=obj.yarn_node_http_address,
                    start_time=datetime_from_millis(obj.start_time),
-                   finish_time=datetime_from_millis(obj.finish_time))
+                   finish_time=datetime_from_millis(obj.finish_time),
+                   exit_message=obj.exit_message)

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -78,9 +78,9 @@ def check_is_shutdown(client, app_id, status=None):
 
 def wait_for_completion(client, app_id, timeout=30):
     while timeout:
-        report = client.application_report(app_id)
-        if report.final_status != 'undefined':
-            return report.final_status
+        final_status = client.application_report(app_id).final_status
+        if final_status != 'UNDEFINED':
+            return final_status
         time.sleep(0.1)
         timeout -= 0.1
     else:

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -76,17 +76,15 @@ def check_is_shutdown(client, app_id, status=None):
         assert client.application_report(app_id).final_status == status
 
 
-def wait_for_success(client, app_id, timeout=30):
+def wait_for_completion(client, app_id, timeout=30):
     while timeout:
-        state = client.application_report(app_id).state
-        if state == 'FINISHED':
-            return
-        elif state in ['FAILED', 'KILLED']:
-            assert False, "Application state = %r, expected 'FINISHED'" % state
+        report = client.application_report(app_id)
+        if report.final_status != 'undefined':
+            return report.final_status
         time.sleep(0.1)
         timeout -= 0.1
     else:
-        assert False, "Application timed out"
+        assert False, 'Application timed out'
 
 
 @contextmanager

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -347,10 +347,10 @@ def test_mem_limit_exceeded(client):
                             commands=commands)
     spec = skein.ApplicationSpec(name="test_mem_limit_exceeded",
                                  queue="default",
-                                 services={'service': service})
+                                 services={"service": service})
 
     with run_application(client, spec=spec) as app:
         assert wait_for_completion(client, app.id) == "FAILED"
 
     logs = get_logs(app.id)
-    assert "Container killed by YARN for exceeding memory limits" in logs
+    assert "Container killed by YARN" in logs

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -1,7 +1,6 @@
 from __future__ import print_function, division, absolute_import
 
 import os
-import re
 import weakref
 
 import pytest
@@ -345,7 +344,7 @@ def test_mem_limit_exceeded(client):
     commands = [
         'python -c "xs = list(range(5 * 10**6)); import time; time.sleep(5)"'
     ]
-    service = skein.Service(resources=skein.Resources(memory=1, vcores=1),
+    service = skein.Service(resources=skein.Resources(memory=124, vcores=1),
                             commands=commands)
     spec = skein.ApplicationSpec(name="test_mem_limit_exceeded",
                                  queue="default",

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -271,7 +271,7 @@ def test_file_systems(client):
                                  file_systems=["hdfs://master.example.com:9000"])
 
     with run_application(client, spec=spec) as app:
-        wait_for_success(client, app.id)
+        assert wait_for_completion(client, app.id) == "SUCCEEDED"
 
 
 def test_webui(client, has_kerberos_enabled):
@@ -336,7 +336,6 @@ def test_kill_application_removes_appdir(client):
 
     fs = hdfs.connect()
     assert not fs.exists("/user/testuser/.skein/%s" % app.id)
-        assert wait_for_completion(client, app.id) == "SUCCEEDED"
 
 
 def test_mem_limit_exceeded(client):

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -364,14 +364,17 @@ def test_container():
     c = Container(state='RUNNING',
                   start_time=start,
                   finish_time=None,
+                  exit_message="",
                   **kwargs)
     c2 = Container(state='SUCCEEDED',
                    start_time=start,
                    finish_time=finish,
+                   exit_message="Ooops",
                    **kwargs)
     c3 = Container(state='WAITING',
                    start_time=None,
                    finish_time=None,
+                   exit_message="",
                    **kwargs)
 
     check_base_methods(c, c2)


### PR DESCRIPTION
Ideally, there should be a dedicated container state for YARN-initiated
kills to differentiate them from the user-initiated ones. However, this
could be done in a followup PR.