### PR TITLE
Cleanup appdir for killed applications

### DIFF
--- a/continuous_integration/travis/docker_install.sh
+++ b/continuous_integration/travis/docker_install.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -xe
 
-packages="grpcio pyyaml cryptography pytest flake8 requests"
+packages="grpcio pyyaml cryptography pytest flake8 requests pyarrow nomkl"
 
 if [[ $1 == "2.7" ]]; then
     conda create -n py27 python=2.7 $packages

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -326,3 +326,13 @@ def test_webui(client, has_kerberos_enabled):
         assert resp.status_code == 404
 
         app.shutdown()
+
+
+def test_kill_application_removes_appdir(client):
+    hdfs = pytest.importorskip('pyarrow.hdfs')
+
+    with run_application(client) as app:
+        client.kill_application(app.id)
+
+    fs = hdfs.connect()
+    assert not fs.exists("/user/testuser/.skein/%s" % app.id)


### PR DESCRIPTION
When an application is killed, remove the application staging directory if it exists.

Fixes #69.