### PR TITLE
Fix accidental java-8 only jar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -10,7 +10,7 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <grpc.version>1.11.0</grpc.version>
-    <jetty.version>9.4.11.v20180605</jetty.version>
+    <jetty.version>9.2.10.v20150310</jetty.version>
     <hadoopVersion>2.7.2</hadoopVersion>
   </properties>
 

--- a/java/src/main/java/com/anaconda/skein/WebUI.java
+++ b/java/src/main/java/com/anaconda/skein/WebUI.java
@@ -109,7 +109,10 @@ public class WebUI {
 
     // Issue a 302 redirect to services from homepage
     RewriteHandler rewrite = new RewriteHandler();
-    rewrite.addRule(new RedirectPatternRule("", "/services"));
+    RedirectPatternRule redirect = new RedirectPatternRule();
+    redirect.setPattern("");
+    redirect.setLocation("/services");
+    rewrite.addRule(redirect);
     context.insertHandler(rewrite);
 
     server.setHandler(context);


### PR DESCRIPTION
Accidentally added a jar that was java-8 only (I would have thought
specifying the compiler in maven as 7 would have prevented that, but it
did not). Downgrading jetty version to last java-7 compatible release,
and a tiny api change fixes things.