### PR TITLE
Support for ACLs

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -143,6 +143,10 @@ Application Specification
     :members:
     :inherited-members:
 
+.. autoclass:: ACLs
+    :members:
+    :inherited-members:
+
 
 Application Responses
 ---------------------

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
+import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
@@ -861,6 +862,10 @@ public class ApplicationMaster {
           env.put("HADOOP_USER_NAME", ugi.getUserName());
         }
 
+        Map<ApplicationAccessType, String> acls = new HashMap<ApplicationAccessType, String>();
+        acls.put(ApplicationAccessType.MODIFY_APP, "testuser");
+        acls.put(ApplicationAccessType.VIEW_APP, "testuser");
+
         final ContainerLaunchContext ctx =
             ContainerLaunchContext.newInstance(
                 service.getLocalResources(),
@@ -868,7 +873,7 @@ public class ApplicationMaster {
                 service.getCommands(),
                 null,
                 tokens,
-                null);
+                acls);
 
         executor.execute(
             new Runnable() {

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -23,7 +23,6 @@ import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
 import org.apache.hadoop.yarn.api.protocolrecords.AllocateResponse;
-import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.Container;
 import org.apache.hadoop.yarn.api.records.ContainerExitStatus;
@@ -862,10 +861,6 @@ public class ApplicationMaster {
           env.put("HADOOP_USER_NAME", ugi.getUserName());
         }
 
-        Map<ApplicationAccessType, String> acls = new HashMap<ApplicationAccessType, String>();
-        acls.put(ApplicationAccessType.MODIFY_APP, "testuser");
-        acls.put(ApplicationAccessType.VIEW_APP, "testuser");
-
         final ContainerLaunchContext ctx =
             ContainerLaunchContext.newInstance(
                 service.getLocalResources(),
@@ -873,7 +868,7 @@ public class ApplicationMaster {
                 service.getCommands(),
                 null,
                 tokens,
-                acls);
+                spec.getAcls().getYarnAcls());
 
         executor.execute(
             new Runnable() {

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -175,9 +175,23 @@ public class ApplicationMaster {
         }
     );
 
+    // Forward restricted set of users to the WebUI if:
+    // - ACLs are enabled
+    // - The wildcard * is not in the ui acl
+    Set<String> allowedUsers = null;
+    Model.Acls acls = spec.getAcls();
+    if (acls.getEnable()) {
+      List<String> uiUsers = acls.getUiUsers();
+      if (!uiUsers.contains("*")) {
+        allowedUsers = new HashSet<String>(uiUsers);
+        // The application owner is always allowed
+        allowedUsers.add(ugi.getShortUserName());
+      }
+    }
+
     try {
       ui = WebUI.create(0, appId.toString(), keyValueStore, serviceContexts,
-                        conf, false);
+                        allowedUsers, conf, false);
       ui.start();
     } catch (Exception e) {
       fatal("Failed to start UI server", e);

--- a/java/src/main/java/com/anaconda/skein/Daemon.java
+++ b/java/src/main/java/com/anaconda/skein/Daemon.java
@@ -283,9 +283,7 @@ public class Daemon {
       fsTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
     }
 
-    Map<ApplicationAccessType, String> acls = new HashMap<ApplicationAccessType, String>();
-    acls.put(ApplicationAccessType.MODIFY_APP, "testuser");
-    acls.put(ApplicationAccessType.VIEW_APP, "testuser");
+    Map<ApplicationAccessType, String> acls = spec.getAcls().getYarnAcls();
 
     ContainerLaunchContext amContext = ContainerLaunchContext.newInstance(
         localResources, env, commands, null, fsTokens, acls);

--- a/java/src/main/java/com/anaconda/skein/Daemon.java
+++ b/java/src/main/java/com/anaconda/skein/Daemon.java
@@ -22,8 +22,9 @@ import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.mapreduce.security.TokenCache;
 import org.apache.hadoop.security.Credentials;
 import org.apache.hadoop.security.UserGroupInformation;
-import org.apache.hadoop.yarn.api.ApplicationConstants;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
+import org.apache.hadoop.yarn.api.ApplicationConstants;
+import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ApplicationId;
 import org.apache.hadoop.yarn.api.records.ApplicationReport;
 import org.apache.hadoop.yarn.api.records.ApplicationSubmissionContext;
@@ -282,8 +283,12 @@ public class Daemon {
       fsTokens = ByteBuffer.wrap(dob.getData(), 0, dob.getLength());
     }
 
+    Map<ApplicationAccessType, String> acls = new HashMap<ApplicationAccessType, String>();
+    acls.put(ApplicationAccessType.MODIFY_APP, "testuser");
+    acls.put(ApplicationAccessType.VIEW_APP, "testuser");
+
     ContainerLaunchContext amContext = ContainerLaunchContext.newInstance(
-        localResources, env, commands, null, fsTokens, null);
+        localResources, env, commands, null, fsTokens, acls);
 
     appContext.setApplicationType("skein");
     appContext.setAMContainerSpec(amContext);

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -2,6 +2,7 @@ package com.anaconda.skein;
 
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.yarn.api.ApplicationConstants.Environment;
+import org.apache.hadoop.yarn.api.records.ApplicationAccessType;
 import org.apache.hadoop.yarn.api.records.ContainerId;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.NodeId;
@@ -9,6 +10,7 @@ import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
 
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -104,24 +106,76 @@ public class Model {
     }
   }
 
+  public static class Acls {
+    private List<String> viewUsers;
+    private List<String> viewGroups;
+    private List<String> modifyUsers;
+    private List<String> modifyGroups;
+    private List<String> uiUsers;
+
+    public Acls(List<String> viewUsers, List<String> viewGroups,
+                List<String> modifyUsers, List<String> modifyGroups,
+                List<String> uiUsers) {
+      this.viewUsers = viewUsers;
+      this.viewGroups = viewGroups;
+      this.modifyUsers = modifyUsers;
+      this.modifyGroups = modifyGroups;
+      this.uiUsers = uiUsers;
+    }
+
+    public Map<ApplicationAccessType, String> getYarnAcls() {
+      Map<ApplicationAccessType, String> out = new HashMap<ApplicationAccessType, String>();
+
+      String view = Utils.formatAcl(viewUsers, viewGroups);
+      if (view != null) {
+        out.put(ApplicationAccessType.VIEW_APP, view);
+      }
+
+      String modify = Utils.formatAcl(modifyUsers, modifyGroups);
+      if (modify != null) {
+        out.put(ApplicationAccessType.MODIFY_APP, modify);
+      }
+
+      return out;
+    }
+
+    public void setViewUsers(List<String> viewUsers) { this.viewUsers = viewUsers; }
+    public List<String> getViewUsers() { return viewUsers; }
+
+    public void setViewGroups(List<String> viewGroups) { this.viewGroups = viewGroups; }
+    public List<String> getViewGroups() { return viewGroups; }
+
+    public void setModifyUsers(List<String> modifyUsers) { this.modifyUsers = modifyUsers; }
+    public List<String> getModifyUsers() { return modifyUsers; }
+
+    public void setModifyGroups(List<String> modifyGroups) { this.modifyGroups = modifyGroups; }
+    public List<String> getModifyGroups() { return modifyGroups; }
+
+    public void setUiUsers(List<String> uiUsers) { this.uiUsers = uiUsers; }
+    public List<String> getUiUsers() { return uiUsers; }
+  }
+
   public static class ApplicationSpec {
     private String name;
     private String queue;
     private int maxAttempts;
     private Set<String> tags;
     private List<Path> fileSystems;
+    private Acls acls;
     private Map<String, Service> services;
 
     public ApplicationSpec() {}
 
     public ApplicationSpec(String name, String queue, int maxAttempts,
                            Set<String> tags, List<Path> fileSystems,
+                           Acls acls,
                            Map<String, Service> services) {
       this.name = name;
       this.queue = queue;
       this.maxAttempts = maxAttempts;
       this.tags = tags;
       this.fileSystems = fileSystems;
+      this.acls = acls;
       this.services = services;
     }
 
@@ -151,6 +205,9 @@ public class Model {
       this.fileSystems = fileSystems;
     }
     public List<Path> getFileSystems() { return this.fileSystems; }
+
+    public void setAcls(Acls acls) { this.acls = acls; }
+    public Acls getAcls() { return this.acls; }
 
     public void setServices(Map<String, Service> services) { this.services = services; }
     public Map<String, Service> getServices() { return services; }

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -107,15 +107,17 @@ public class Model {
   }
 
   public static class Acls {
+    private boolean enable;
     private List<String> viewUsers;
     private List<String> viewGroups;
     private List<String> modifyUsers;
     private List<String> modifyGroups;
     private List<String> uiUsers;
 
-    public Acls(List<String> viewUsers, List<String> viewGroups,
-                List<String> modifyUsers, List<String> modifyGroups,
-                List<String> uiUsers) {
+    public Acls(boolean enable, List<String> viewUsers,
+                List<String> viewGroups, List<String> modifyUsers,
+                List<String> modifyGroups, List<String> uiUsers) {
+      this.enable = enable;
       this.viewUsers = viewUsers;
       this.viewGroups = viewGroups;
       this.modifyUsers = modifyUsers;
@@ -124,20 +126,19 @@ public class Model {
     }
 
     public Map<ApplicationAccessType, String> getYarnAcls() {
+      if (!enable) {
+        return null;
+      }
       Map<ApplicationAccessType, String> out = new HashMap<ApplicationAccessType, String>();
 
-      String view = Utils.formatAcl(viewUsers, viewGroups);
-      if (view != null) {
-        out.put(ApplicationAccessType.VIEW_APP, view);
-      }
-
-      String modify = Utils.formatAcl(modifyUsers, modifyGroups);
-      if (modify != null) {
-        out.put(ApplicationAccessType.MODIFY_APP, modify);
-      }
+      out.put(ApplicationAccessType.VIEW_APP, Utils.formatAcl(viewUsers, viewGroups));
+      out.put(ApplicationAccessType.MODIFY_APP, Utils.formatAcl(modifyUsers, modifyGroups));
 
       return out;
     }
+
+    public void setEnable(boolean enable) { this.enable = enable; }
+    public boolean getEnable() { return enable; }
 
     public void setViewUsers(List<String> viewUsers) { this.viewUsers = viewUsers; }
     public List<String> getViewUsers() { return viewUsers; }

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -297,12 +297,52 @@ public class MsgUtils {
         new HashSet<String>(service.getDependsList()));
   }
 
+  public static Msg.Acls writeAcls(Model.Acls acl) {
+    Msg.Acls.Builder builder = Msg.Acls.newBuilder();
+
+    List<String> aclList;
+
+    aclList = acl.getViewUsers();
+    if (aclList != null) {
+      builder.getViewUsersBuilder().addAllValues(aclList);
+    }
+    aclList = acl.getViewGroups();
+    if (aclList != null) {
+      builder.getViewGroupsBuilder().addAllValues(aclList);
+    }
+    aclList = acl.getModifyUsers();
+    if (aclList != null) {
+      builder.getModifyUsersBuilder().addAllValues(aclList);
+    }
+    aclList = acl.getModifyGroups();
+    if (aclList != null) {
+      builder.getModifyGroupsBuilder().addAllValues(aclList);
+    }
+    aclList = acl.getUiUsers();
+    if (aclList != null) {
+      builder.getUiUsersBuilder().addAllValues(aclList);
+    }
+
+    return builder.build();
+  }
+
+  public static Model.Acls readAcls(Msg.Acls acl) {
+    return new Model.Acls(
+        acl.hasViewUsers() ? acl.getViewUsers().getValuesList() : null,
+        acl.hasViewGroups() ? acl.getViewGroups().getValuesList() : null,
+        acl.hasModifyUsers() ? acl.getModifyUsers().getValuesList() : null,
+        acl.hasModifyGroups() ? acl.getModifyGroups().getValuesList() : null,
+        acl.hasUiUsers() ? acl.getUiUsers().getValuesList() : null
+    );
+  }
+
   public static Msg.ApplicationSpec writeApplicationSpec(Model.ApplicationSpec spec) {
     Msg.ApplicationSpec.Builder builder = Msg.ApplicationSpec.newBuilder()
         .setName(spec.getName())
         .setQueue(spec.getQueue())
         .setMaxAttempts(spec.getMaxAttempts())
         .addAllTags(spec.getTags())
+        .setAcls(writeAcls(spec.getAcls()))
         .addAllFileSystems(Lists.transform(spec.getFileSystems(), Functions.toStringFunction()));
 
     for (Map.Entry<String, Model.Service> entry : spec.getServices().entrySet()) {
@@ -326,6 +366,7 @@ public class MsgUtils {
                                      spec.getMaxAttempts(),
                                      new HashSet<String>(spec.getTagsList()),
                                      fileSystems,
+                                     readAcls(spec.getAcls()),
                                      services);
   }
 

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -298,41 +298,24 @@ public class MsgUtils {
   }
 
   public static Msg.Acls writeAcls(Model.Acls acl) {
-    Msg.Acls.Builder builder = Msg.Acls.newBuilder();
-
-    List<String> aclList;
-
-    aclList = acl.getViewUsers();
-    if (aclList != null) {
-      builder.getViewUsersBuilder().addAllValues(aclList);
-    }
-    aclList = acl.getViewGroups();
-    if (aclList != null) {
-      builder.getViewGroupsBuilder().addAllValues(aclList);
-    }
-    aclList = acl.getModifyUsers();
-    if (aclList != null) {
-      builder.getModifyUsersBuilder().addAllValues(aclList);
-    }
-    aclList = acl.getModifyGroups();
-    if (aclList != null) {
-      builder.getModifyGroupsBuilder().addAllValues(aclList);
-    }
-    aclList = acl.getUiUsers();
-    if (aclList != null) {
-      builder.getUiUsersBuilder().addAllValues(aclList);
-    }
-
-    return builder.build();
+    return Msg.Acls.newBuilder()
+              .setEnable(acl.getEnable())
+              .addAllViewUsers(acl.getViewUsers())
+              .addAllViewGroups(acl.getViewGroups())
+              .addAllModifyUsers(acl.getModifyUsers())
+              .addAllModifyGroups(acl.getModifyGroups())
+              .addAllUiUsers(acl.getUiUsers())
+              .build();
   }
 
   public static Model.Acls readAcls(Msg.Acls acl) {
     return new Model.Acls(
-        acl.hasViewUsers() ? acl.getViewUsers().getValuesList() : null,
-        acl.hasViewGroups() ? acl.getViewGroups().getValuesList() : null,
-        acl.hasModifyUsers() ? acl.getModifyUsers().getValuesList() : null,
-        acl.hasModifyGroups() ? acl.getModifyGroups().getValuesList() : null,
-        acl.hasUiUsers() ? acl.getUiUsers().getValuesList() : null
+        acl.getEnable(),
+        acl.getViewUsersList(),
+        acl.getViewGroupsList(),
+        acl.getModifyUsersList(),
+        acl.getModifyGroupsList(),
+        acl.getUiUsersList()
     );
   }
 

--- a/java/src/main/java/com/anaconda/skein/Utils.java
+++ b/java/src/main/java/com/anaconda/skein/Utils.java
@@ -73,13 +73,8 @@ public class Utils {
   }
 
   public static String formatAcl(List<String> users, List<String> groups) {
-    if (users == null && groups == null) {
-      return null;
-    }
-
     // "*" in either groups or users -> "*"
-    if ((users != null && users.contains("*"))
-        || (groups != null && groups.contains("*"))) {
+    if (users.contains("*") || groups.contains("*")) {
       return "*";
     }
 

--- a/java/src/main/java/com/anaconda/skein/Utils.java
+++ b/java/src/main/java/com/anaconda/skein/Utils.java
@@ -1,5 +1,7 @@
 package com.anaconda.skein;
 
+import com.google.common.base.Joiner;
+
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -15,6 +17,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
@@ -67,6 +70,33 @@ public class Utils {
         minCount, maxCount, 60, TimeUnit.SECONDS,
         new LinkedBlockingQueue<Runnable>(),
         new CustomThreadFactory(name, isDaemon));
+  }
+
+  public static String formatAcl(List<String> users, List<String> groups) {
+    if (users == null && groups == null) {
+      return null;
+    }
+
+    // "*" in either groups or users -> "*"
+    if ((users != null && users.contains("*"))
+        || (groups != null && groups.contains("*"))) {
+      return "*";
+    }
+
+    StringBuilder builder = new StringBuilder();
+    Joiner joiner = Joiner.on(",");
+
+    if (users != null) {
+      joiner.appendTo(builder, users);
+    }
+
+    builder.append(" ");
+
+    if (groups != null) {
+      joiner.appendTo(builder, groups);
+    }
+
+    return builder.toString();
   }
 
   public static ApplicationId appIdFromString(String appId) {

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -14,11 +14,6 @@ message Empty {
 }
 
 
-message NullableStringList {
-  repeated string values = 1;
-}
-
-
 message FinalStatus {
   enum Type {
     UNDEFINED = 0;
@@ -88,11 +83,12 @@ message Service {
 
 
 message Acls {
-  NullableStringList view_users = 1;
-  NullableStringList view_groups = 2;
-  NullableStringList modify_users = 3;
-  NullableStringList modify_groups = 4;
-  NullableStringList ui_users = 5;
+  bool enable = 1;
+  repeated string view_users = 2;
+  repeated string view_groups = 3;
+  repeated string modify_users = 4;
+  repeated string modify_groups = 5;
+  repeated string ui_users = 6;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -14,6 +14,11 @@ message Empty {
 }
 
 
+message NullableStringList {
+  repeated string values = 1;
+}
+
+
 message FinalStatus {
   enum Type {
     UNDEFINED = 0;
@@ -82,13 +87,23 @@ message Service {
 }
 
 
+message Acls {
+  NullableStringList view_users = 1;
+  NullableStringList view_groups = 2;
+  NullableStringList modify_users = 3;
+  NullableStringList modify_groups = 4;
+  NullableStringList ui_users = 5;
+}
+
+
 message ApplicationSpec {
   string name = 1;
   string queue = 2;
   int32 max_attempts = 3;
   repeated string tags = 4;
   repeated string file_systems = 5;
-  map<string, Service> services = 6;
+  Acls acls = 6;
+  map<string, Service> services = 7;
 }
 
 

--- a/java/src/test/java/com/anaconda/skein/TestUtils.java
+++ b/java/src/test/java/com/anaconda/skein/TestUtils.java
@@ -11,25 +11,16 @@ import java.util.List;
 public class TestUtils {
   @Test
   public void testFormatAcl() {
-    assertEquals(Utils.formatAcl(null, null), null);
-
     List<String> empty = Lists.newArrayList();
     List<String> star = Lists.newArrayList("*");
     List<String> hasStar = Lists.newArrayList("other", "*");
 
-    assertEquals(Utils.formatAcl(star, null), "*");
-    assertEquals(Utils.formatAcl(null, star), "*");
-    assertEquals(Utils.formatAcl(hasStar, null), "*");
-    assertEquals(Utils.formatAcl(null, hasStar), "*");
+    assertEquals(Utils.formatAcl(empty, star), "*");
+    assertEquals(Utils.formatAcl(star, empty), "*");
     assertEquals(Utils.formatAcl(empty, hasStar), "*");
     assertEquals(Utils.formatAcl(hasStar, empty), "*");
-
-    assertEquals(Utils.formatAcl(empty, null), " ");
-    assertEquals(Utils.formatAcl(null, empty), " ");
     assertEquals(Utils.formatAcl(empty, empty), " ");
 
-    assertEquals(Utils.formatAcl(Lists.newArrayList("a", "b"), null), "a,b ");
-    assertEquals(Utils.formatAcl(null, Lists.newArrayList("a", "b")), " a,b");
     assertEquals(Utils.formatAcl(Lists.newArrayList("a", "b"), empty), "a,b ");
     assertEquals(Utils.formatAcl(empty, Lists.newArrayList("a", "b")), " a,b");
     assertEquals(Utils.formatAcl(Lists.newArrayList("a", "b"),

--- a/java/src/test/java/com/anaconda/skein/TestUtils.java
+++ b/java/src/test/java/com/anaconda/skein/TestUtils.java
@@ -1,0 +1,39 @@
+package com.anaconda.skein;
+
+import static org.junit.Assert.assertEquals;
+
+import com.google.common.collect.Lists;
+
+import org.junit.Test;
+
+import java.util.List;
+
+public class TestUtils {
+  @Test
+  public void testFormatAcl() {
+    assertEquals(Utils.formatAcl(null, null), null);
+
+    List<String> empty = Lists.newArrayList();
+    List<String> star = Lists.newArrayList("*");
+    List<String> hasStar = Lists.newArrayList("other", "*");
+
+    assertEquals(Utils.formatAcl(star, null), "*");
+    assertEquals(Utils.formatAcl(null, star), "*");
+    assertEquals(Utils.formatAcl(hasStar, null), "*");
+    assertEquals(Utils.formatAcl(null, hasStar), "*");
+    assertEquals(Utils.formatAcl(empty, hasStar), "*");
+    assertEquals(Utils.formatAcl(hasStar, empty), "*");
+
+    assertEquals(Utils.formatAcl(empty, null), " ");
+    assertEquals(Utils.formatAcl(null, empty), " ");
+    assertEquals(Utils.formatAcl(empty, empty), " ");
+
+    assertEquals(Utils.formatAcl(Lists.newArrayList("a", "b"), null), "a,b ");
+    assertEquals(Utils.formatAcl(null, Lists.newArrayList("a", "b")), " a,b");
+    assertEquals(Utils.formatAcl(Lists.newArrayList("a", "b"), empty), "a,b ");
+    assertEquals(Utils.formatAcl(empty, Lists.newArrayList("a", "b")), " a,b");
+    assertEquals(Utils.formatAcl(Lists.newArrayList("a", "b"),
+                                 Lists.newArrayList("c", "d")),
+                 "a,b c,d");
+  }
+}

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -4,7 +4,7 @@ from .exceptions import (SkeinError, ConnectionError, DaemonNotRunningError,
                          ApplicationNotRunningError, DaemonError,
                          ApplicationError)
 from .model import (ApplicationSpec, Service, File, Resources, FileType,
-                    FileVisibility)
+                    FileVisibility, ACLs)
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
-                        Service, ApplicationSpec, ResourceUsageReport,
+                        Service, Acls, ApplicationSpec, ResourceUsageReport,
                         ApplicationReport, Application, ApplicationsRequest,
                         Url, ContainersRequest, Container, ContainerInstance,
                         ScaleRequest, ShutdownRequest)

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -9,7 +9,7 @@ import pytest
 
 from skein.compatibility import UTC
 from skein.model import (ApplicationSpec, Service, Resources, File,
-                         ApplicationState, FinalStatus, FileType,
+                         ApplicationState, FinalStatus, FileType, ACLs,
                          Container, ApplicationReport, ResourceUsageReport)
 
 
@@ -45,6 +45,11 @@ tags:
     - tag2
 file_systems:
     - hdfs://preprod
+
+acls:
+    enable: true
+    view_users:
+        - '*'
 
 services:
     service_1:
@@ -149,6 +154,20 @@ def test_file_invariants():
     assert f.type == FileType.FILE
     f.type = 'archive'
     assert f.type == FileType.ARCHIVE
+
+
+def test_acls():
+    acl1 = ACLs()
+    acl2 = ACLs(enable=True, view_users=['ted', 'nancy'])
+    check_specification_methods(acl1, acl2)
+
+
+def test_acls_invariants():
+    with pytest.raises(TypeError):
+        ACLs(enable=1)
+
+    with pytest.raises(TypeError):
+        ACLs(view_users="*")
 
 
 def test_service():
@@ -287,6 +306,8 @@ def test_application_spec_from_yaml():
     assert spec.tags == {'tag1', 'tag2'}
     assert spec.file_systems == ['hdfs://preprod']
     assert spec.max_attempts == 2
+    assert spec.acls.enable
+    assert spec.acls.view_users == ['*']
     assert isinstance(spec.services, dict)
     assert isinstance(spec.services['service_1'], Service)
 


### PR DESCRIPTION
Adds support for Access Control Lists (ACLs). This allows filtering permissions on users/groups. Three access categories are supported:

- VIEW: view application details. This comes from yarn, we only forward the request.
- MODIFY: modify application.  This comes from yarn, we only forward the request. AFAICT this only disables support for others killing the application.
- UI: access the web ui. This is implemented in skein.

The first two are just forwarding application acls to YARN, and match YARN's semantics and defaults. Note that while these parameters will be forwarded in all cases, YARN will ignore them unless the cluster has been properly configured. See https://www.cloudera.com/documentation/enterprise/6/6.0/topics/cm_mc_yarn_service1.html for more information.

By default, ACLs are disabled. If enabled, the default behavior is to restrict access for all 3 categories to only the application owner. Note that the application owner will always have access. Additional access can be granted for other users/groups as needed. The wildcard `"*"` can be used to mean "all users". All of this matches yarn/spark's behavior and defaults.

From a specification standpoint, this looks like:

```yaml
# Enables acls
# Gives ui permissions to tom and nancy,
# modify access to anyone in the engineering group,
# and view access to everyone
acls:
  enable: true
  ui_users:
    - tom
    - nancy
  modify_groups:
    - engineering
  view_users:
    - '*'
```

Fixes #74.