### PR TITLE
Logging and debugging improvements

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -158,6 +158,10 @@ Application Specification
     :members:
     :inherited-members:
 
+.. autoclass:: Master
+    :members:
+    :inherited-members:
+
 
 Application Responses
 ---------------------

--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -43,7 +43,7 @@ the full container environment before executing any application specific
 commands. This includes all localized paths, and all environment variables.
 Since ``skein`` accepts multiple commands for each service, this is easy to do.
 
-.. code-block:: console
+.. code-block:: none
 
     services:
       my_service:
@@ -58,6 +58,24 @@ Since ``skein`` accepts multiple commands for each service, this is easy to do.
 It's also useful to log application logic as your application progresses. This
 could as simple as periodic ``print`` statements, or using the standard
 library's `logging module <https://docs.python.org/3/library/logging.html>`_.
+
+
+Configuring Logging in the Application Master
+---------------------------------------------
+
+Skein's `Application Master
+<https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/YARN.html>`__
+uses `Log4j <http://logging.apache.org/log4j/1.2/>`__ for logging. The default
+log configuration can be overridden by specifying a custom ``log4j.properties``
+file in the `specification <specification.html>`__. When debugging issues in
+Skein itself, it can be useful to increase the log level to provide more
+information. See the `Log4j documentation
+<https://logging.apache.org/log4j/1.2/>`__ for more information.
+
+.. code-block:: none
+
+    master:
+      log_config: path/to/my/log4j.properties
 
 
 Start a Remote IPython Kernel on the Container

--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -65,16 +65,24 @@ Configuring Logging in the Application Master
 
 Skein's `Application Master
 <https://hadoop.apache.org/docs/stable/hadoop-yarn/hadoop-yarn-site/YARN.html>`__
-uses `Log4j <http://logging.apache.org/log4j/1.2/>`__ for logging. The default
-log configuration can be overridden by specifying a custom ``log4j.properties``
-file in the `specification <specification.html>`__. When debugging issues in
+uses `Log4j <http://logging.apache.org/log4j/1.2/>`__ for logging.
+When debugging issues in
 Skein itself, it can be useful to increase the log level to provide more
-information. See the `Log4j documentation
-<https://logging.apache.org/log4j/1.2/>`__ for more information.
+information. This can be accomplished two different ways:
+
+- Change the logging level with the ``log_level`` field (``debug`` is a good option).
+- Override the defaul log configuration by specifying a custom
+  ``log4j.properties`` file in the `specification <specification.html>`__. This
+  allows you to increase the logging level for component libraries as well. See
+  the `Log4j documentation <https://logging.apache.org/log4j/1.2/>`__ for more
+  information on configuration files.
 
 .. code-block:: none
 
     master:
+      # Change the log level to debug
+      log_level: debug
+      # OR provide a custom log configuration file
       log_config: path/to/my/log4j.properties
 
 

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -134,6 +134,12 @@ common use the defaults should be sufficient.
 
 Supported subfields are:
 
+- ``log_level``: The application master log level. Possible values are (from
+  most to least verbose): ``all``, ``trace``, ``debug``, ``info``, ``warn``,
+  ``error``, ``fatal`` or ``off``. Default is ``info``. Note that this sets
+  the ``skein.log.level`` system property, which is used in the default
+  ``log4j.properties`` file - if you provide your own ``log4j.properties`` file
+  this field may have no effect.
 - ``log_config``: a path to a custom ``log4j.properties`` file. Could be local
   or on a remote filesystem. If not provided, a default logging configuration
   is used. See the `Log4j documentation <https://logging.apache.org/log4j/1.2/>`__

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -112,10 +112,10 @@ Supported subfields are:
     enable: True    # Enable ACLs. Without this ACLs will be ignored.
 
     ui_users:
-    - "*"           # Give all users access to the Web UI
+      - "*"           # Give all users access to the Web UI
 
     view_users:
-    - nancy         # Give nancy view access
+      - nancy         # Give nancy view access
 
     # The application owner always has access to all access types. Since
     # `modify_users`/`modify_groups` are unchanged, only the owner has modify
@@ -125,6 +125,26 @@ For more information on ACLs see:
 
 - Cloudera's `documentation on YARN ACLs <https://www.cloudera.com/documentation/enterprise/6/6.0/topics/cm_mc_yarn_service1.html>`__
 - The :class:`ACLs` docstring
+
+``master``
+~~~~~~~~~~
+
+Additional configuration tuning for the Application Master. Optional. Under
+common use the defaults should be sufficient.
+
+Supported subfields are:
+
+- ``log_config``: a path to a custom ``log4j.properties`` file. Could be local
+  or on a remote filesystem. If not provided, a default logging configuration
+  is used. See the `Log4j documentation <https://logging.apache.org/log4j/1.2/>`__
+  for more information.
+
+**Example**
+
+.. code-block:: none
+
+  master:
+    log_config: path/to/my/log4j.properties
 
 ``services``
 ~~~~~~~~~~~~

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -227,6 +227,20 @@
     </dependency>
 
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.10</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-log4j12</artifactId>
+      <version>1.7.10</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-common</artifactId>
       <version>${hadoopVersion}</version>

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -330,8 +330,6 @@ public class ApplicationMaster {
 
     List<Container> allocated = resp.getAllocatedContainers();
     List<ContainerStatus> completed = resp.getCompletedContainersStatuses();
-    LOG.debug("Received {} new containers, {} completed containers.",
-              allocated.size(), completed.size());
 
     if (allocated.size() > 0) {
       handleAllocated(allocated);
@@ -347,6 +345,8 @@ public class ApplicationMaster {
   }
 
   private void handleAllocated(List<Container> newContainers) {
+    LOG.debug("Received {} new containers", newContainers.size());
+
     for (Container c : newContainers) {
       Priority priority = c.getPriority();
       Resource resource = c.getResource();
@@ -363,6 +363,8 @@ public class ApplicationMaster {
   }
 
   private void handleCompleted(List<ContainerStatus> containerStatuses) {
+    LOG.debug("Received {} completed containers", containerStatuses.size());
+
     for (ContainerStatus status : containerStatuses) {
       Model.Container container = containers.get(status.getContainerId());
       if (container == null) {
@@ -380,7 +382,7 @@ public class ApplicationMaster {
           return;  // state change already handled by killContainer
         case ContainerExitStatus.SUCCESS:
           state = Model.Container.State.SUCCEEDED;
-          exitMessage = "Completed successfully";
+          exitMessage = "Completed successfully.";
           break;
         case ContainerExitStatus.KILLED_EXCEEDED_PMEM:
           state = Model.Container.State.FAILED;
@@ -398,7 +400,7 @@ public class ApplicationMaster {
           state = Model.Container.State.FAILED;
           if (status.getExitStatus() > 0) {
             // Positive error codes indicate service failure
-            exitMessage = "Container failed during execution, see logs for more information";
+            exitMessage = "Container failed during execution, see logs for more information.";
           } else {
             exitMessage = status.getDiagnostics();
           }
@@ -980,9 +982,9 @@ public class ApplicationMaster {
           }
 
           if (warn) {
-            LOG.warn("{}: {}, {}", state, container.getId(), exitMessage);
+            LOG.warn("{}: {} - {}", state, container.getId(), exitMessage);
           } else {
-            LOG.info("{}: {}, {}", state, container.getId(), exitMessage);
+            LOG.info("{}: {} - {}", state, container.getId(), exitMessage);
           }
 
           container.setState(state);

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -38,8 +38,8 @@ import org.apache.hadoop.yarn.client.api.NMClient;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.security.AMRMTokenIdentifier;
-import org.apache.log4j.LogManager;
-import org.apache.log4j.Logger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileInputStream;
@@ -66,7 +66,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 
 public class ApplicationMaster {
 
-  private static final Logger LOG = LogManager.getLogger(ApplicationMaster.class);
+  private static final Logger LOG = LoggerFactory.getLogger(ApplicationMaster.class);
 
   // One for the boss, one for the worker. Should be fine under normal loads.
   private static final int NUM_EVENT_LOOP_GROUP_THREADS = 2;
@@ -139,8 +139,6 @@ public class ApplicationMaster {
         .build()
         .start();
 
-    LOG.info("gRPC server started, listening on " + grpcServer.getPort());
-
     Runtime.getRuntime().addShutdownHook(
         new Thread() {
           @Override
@@ -148,11 +146,12 @@ public class ApplicationMaster {
             ApplicationMaster.this.stopServer();
           }
         });
+
+    LOG.info("gRPC server started, listening on {}", grpcServer.getPort());
   }
 
   private void stopServer() {
     if (grpcServer != null) {
-      LOG.info("Shutting down gRPC server");
       grpcServer.shutdown();
       LOG.info("gRPC server shut down");
     }
@@ -194,7 +193,7 @@ public class ApplicationMaster {
                      allowedUsers, conf, false);
       ui.start();
     } catch (Exception e) {
-      fatal("Failed to start UI server", e);
+      fatal("Failed to start WebUI server", e);
     }
 
     Runtime.getRuntime().addShutdownHook(
@@ -205,12 +204,11 @@ public class ApplicationMaster {
           }
         });
 
-    LOG.info("UI server started, listening on " + ui.getURI().getPort());
+    LOG.info("WebUI server started, listening on {}", ui.getURI().getPort());
   }
 
   private void stopUI() {
     if (ui != null) {
-      LOG.info("Shutting down WebUI server");
       ui.stop();
       LOG.info("WebUI server shut down");
     }
@@ -332,6 +330,8 @@ public class ApplicationMaster {
 
     List<Container> allocated = resp.getAllocatedContainers();
     List<ContainerStatus> completed = resp.getCompletedContainersStatuses();
+    LOG.debug("Received {} new containers, {} completed containers.",
+              allocated.size(), completed.size());
 
     if (allocated.size() > 0) {
       handleAllocated(allocated);
@@ -355,8 +355,8 @@ public class ApplicationMaster {
       if (tracker != null && tracker.matches(resource)) {
         tracker.startContainer(c, resource);
       } else {
-        LOG.warn("No matching service found for resource: " + resource
-                 + ", priority: " + priority + ", releasing " + c.getId());
+        LOG.warn("No matching service found for resource {}, priority {}, releasing {}",
+                 resource, priority, c.getId());
         rmClient.releaseAssignedContainer(c.getId());
       }
     }
@@ -366,38 +366,58 @@ public class ApplicationMaster {
     for (ContainerStatus status : containerStatuses) {
       Model.Container container = containers.get(status.getContainerId());
       if (container == null) {
-        continue;  // release container that was never started
+        // released container that was never started
+        LOG.debug("Releasing newly allocated container {} due to canceled request",
+                  status.getContainerId());
+        continue;
       }
 
       Model.Container.State state;
-      int exitStatus = status.getExitStatus();
+      String exitMessage;
 
-      if (exitStatus == ContainerExitStatus.SUCCESS) {
-        state = Model.Container.State.SUCCEEDED;
-      } else if (exitStatus == ContainerExitStatus.KILLED_BY_APPMASTER) {
-        return;  // state change already handled by killContainer
-      } else {
-        state = Model.Container.State.FAILED;
+      switch (status.getExitStatus()) {
+        case ContainerExitStatus.KILLED_BY_APPMASTER:
+          return;  // state change already handled by killContainer
+        case ContainerExitStatus.SUCCESS:
+          state = Model.Container.State.SUCCEEDED;
+          exitMessage = "Completed successfully";
+          break;
+        case ContainerExitStatus.KILLED_EXCEEDED_PMEM:
+          state = Model.Container.State.FAILED;
+          exitMessage = Utils.formatExceededMemMessage(
+              status.getDiagnostics(),
+              Utils.EXCEEDED_PMEM_PATTERN);
+          break;
+        case ContainerExitStatus.KILLED_EXCEEDED_VMEM:
+          state = Model.Container.State.FAILED;
+          exitMessage = Utils.formatExceededMemMessage(
+              status.getDiagnostics(),
+              Utils.EXCEEDED_VMEM_PATTERN);
+          break;
+        default:
+          state = Model.Container.State.FAILED;
+          if (status.getExitStatus() > 0) {
+            // Positive error codes indicate service failure
+            exitMessage = "Container failed during execution, see logs for more information";
+          } else {
+            exitMessage = status.getDiagnostics();
+          }
+          break;
       }
 
       services.get(container.getServiceName())
-              .finishContainer(container.getInstance(), state);
+              .finishContainer(container.getInstance(), state, exitMessage);
     }
   }
 
   private static void fatal(String msg, Throwable exc) {
-    LOG.fatal(msg, exc);
-    System.exit(1);
-  }
-
-  private static void fatal(String msg) {
-    LOG.fatal(msg);
+    LOG.error(msg, exc);
     System.exit(1);
   }
 
   public void init(String[] args) {
     if (args.length == 0 || args.length > 2) {
-      LOG.fatal("Usage: <command> applicationDirectory applicationId");
+      LOG.error("Usage: <command> applicationDirectory applicationId");
       System.exit(1);
     }
     appDir = new Path(args[0]);
@@ -417,7 +437,8 @@ public class ApplicationMaster {
 
     // Create ugi and add original tokens to it
     String userName = System.getenv(Environment.USER.name());
-    LOG.info("user: " + userName);
+    LOG.info("Running as user {}", userName);
+
     ugi = UserGroupInformation.createRemoteUser(userName);
 
     Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
@@ -478,17 +499,19 @@ public class ApplicationMaster {
       }
     }
     if (finished) {
-      shutdown(FinalApplicationStatus.SUCCEEDED, "Completed Successfully");
+      shutdown(FinalApplicationStatus.SUCCEEDED,
+               "Application completed successfully.");
     }
   }
 
   private void shutdown(FinalApplicationStatus status, String msg) {
     preshutdown(status, msg);
-
     System.exit(0);  // Trigger exit hooks
   }
 
   private void preshutdown(FinalApplicationStatus status, String msg) {
+    LOG.info("Shutting down: {}", msg);
+
     try {
       rmClient.unregisterApplicationMaster(status, msg, null);
     } catch (Exception ex) {
@@ -503,9 +526,9 @@ public class ApplicationMaster {
             try {
               FileSystem fs = FileSystem.get(conf);
               fs.delete(appDir, true);
-              LOG.info("Deleted application directory " + appDir);
+              LOG.info("Deleted application directory {}", appDir);
             } catch (IOException exc) {
-              LOG.warn("Failed to delete application directory " + appDir, exc);
+              LOG.warn("Failed to delete application directory {}", appDir, exc);
             }
             return null;
           }
@@ -543,7 +566,7 @@ public class ApplicationMaster {
         synchronized (keyValueStore) {
           intervalTree.remove(watchId);
         }
-        LOG.info("Removed Watcher " + watchId);
+        LOG.debug("Removed Watcher [id: {}]", watchId);
       }
     }
 
@@ -552,7 +575,7 @@ public class ApplicationMaster {
         for (Iterator<Integer> it = registered.iterator(); it.hasNext();) {
           int watchId = it.next();
           intervalTree.remove(watchId);
-          LOG.info("Removed Watcher " + watchId);
+          LOG.debug("Removed Watcher [id: {}]", watchId);
           it.remove();
         }
       }
@@ -573,11 +596,8 @@ public class ApplicationMaster {
           synchronized (keyValueStore) {
             watchId = intervalTree.add(start, end, new Watcher(resp, this, type));
           }
-          LOG.info("Created Watcher."
-                   + " id=" + watchId
-                   + ", start=" + start
-                   + ", end=" + end
-                   + ", type=" + type);
+          LOG.debug("Created Watcher [id: {}, start: {}, end: {}, type: {}]",
+                    watchId, start, end, type);
           registered.add(watchId);
           builder.setWatchId(watchId);
           builder.setType(Msg.WatchResponse.Type.CREATE);
@@ -642,7 +662,8 @@ public class ApplicationMaster {
           resp.onNext(msg);
         } catch (StatusRuntimeException exc) {
           if (exc.getStatus().getCode() != Status.Code.CANCELLED) {
-            LOG.info("Watcher " + watchId + " failed to send, got status: " + exc.getStatus());
+            LOG.warn("Watcher {} failed to send, got status {}",
+                     watchId, exc.getStatus());
           }
           req.removeAllWatches();
         }
@@ -731,7 +752,7 @@ public class ApplicationMaster {
     }
 
     public void initialize() throws IOException {
-      LOG.info("INTIALIZING: " + name);
+      LOG.info("Initializing service '{}'.", name);
       // Request initial containers
       for (int i = 0; i < service.getInstances(); i++) {
         addContainer();
@@ -783,8 +804,8 @@ public class ApplicationMaster {
         synchronized (this) {
           int active = getNumActive();
           int delta = instances - active;
-          LOG.info("Scaling service '" + name + "' to " + instances
-                   + " instances, a delta of " + delta);
+          LOG.info("Scaling service '{}' to {} instances, a delta of {}.",
+                   name, instances, delta);
           if (delta > 0) {
             // Scale up
             for (int i = 0; i < delta; i++) {
@@ -802,7 +823,8 @@ public class ApplicationMaster {
               } else {
                 instance = Utils.popfirst(running);
               }
-              finishContainer(instance, Model.Container.State.KILLED);
+              finishContainer(instance, Model.Container.State.KILLED,
+                              "Killed by user request.");
               out.add(containers.get(instance));
             }
           }
@@ -818,7 +840,7 @@ public class ApplicationMaster {
       container.setContainerRequest(req);
       rmClient.addContainerRequest(req);
       requested.put(priority, container);
-      LOG.info("REQUESTED: " + container.getId());
+      LOG.info("REQUESTED: {}", container.getId());
     }
 
     public synchronized Model.Container addContainer() {
@@ -827,7 +849,7 @@ public class ApplicationMaster {
         container = new Model.Container(name, containers.size(),
                                         Model.Container.State.WAITING);
         waiting.add(container.getInstance());
-        LOG.info("WAITING: " + container.getId());
+        LOG.info("WAITING: {}", container.getId());
       } else {
         container = new Model.Container(name, containers.size(),
                                         Model.Container.State.REQUESTED);
@@ -839,7 +861,7 @@ public class ApplicationMaster {
 
     public Model.Container startContainer(final Container container,
         Resource resource) {
-      LOG.info("Starting " + container.getId());
+      LOG.info("Starting {}...", container.getId());
       Priority priority = container.getPriority();
       removePriority(priority);
 
@@ -891,15 +913,15 @@ public class ApplicationMaster {
                 try {
                   nmClient.startContainer(container, ctx);
                 } catch (Throwable exc) {
-                  LOG.warn("Failed to start " + ServiceTracker.this.name
-                           + "_" + instance, exc);
+                  LOG.warn("Failed to start {}_{}", ServiceTracker.this.name, instance, exc);
                   ServiceTracker.this.finishContainer(instance,
-                      Model.Container.State.FAILED);
+                      Model.Container.State.FAILED,
+                      "Failed to start, exception raised: " + exc.getMessage());
                 }
               }
             });
 
-        LOG.info("RUNNING: " + out.getId() + " on " + container.getId());
+        LOG.info("RUNNING: {} on {}", out.getId(), container.getId());
       }
 
       if (!initialRunning && requested.size() == 0) {
@@ -911,7 +933,7 @@ public class ApplicationMaster {
       return out;
     }
 
-    public void finishContainer(int instance, Model.Container.State state) {
+    public void finishContainer(int instance, Model.Container.State state, String exitMessage) {
       // Any function that may remove containers, needs to lock the kv store
       // outside the tracker to prevent deadlocks.
       synchronized (keyValueStore) {
@@ -939,6 +961,7 @@ public class ApplicationMaster {
           }
 
           boolean mayRestart = false;
+          boolean warn = false;
           switch (state) {
             case SUCCEEDED:
               numSucceeded += 1;
@@ -949,14 +972,21 @@ public class ApplicationMaster {
             case FAILED:
               numFailed += 1;
               mayRestart = true;
+              warn = true;
               break;
             default:
               throw new IllegalArgumentException(
                   "finishContainer got illegal state " + state);
           }
 
-          LOG.info(state + ": " + container.getId());
+          if (warn) {
+            LOG.warn("{}: {}, {}", state, container.getId(), exitMessage);
+          } else {
+            LOG.info("{}: {}, {}", state, container.getId(), exitMessage);
+          }
+
           container.setState(state);
+          container.setExitMessage(exitMessage);
 
           // Remove any owned keys from the key-value store
           for (String key : container.getOwnedKeys()) {
@@ -977,9 +1007,8 @@ public class ApplicationMaster {
                 }
               }
             } else {
-              LOG.warn("Key '" + key
-                       + "' already deleted, but wasn't removed from "
-                       + "owned-keys set of service " + name);
+              LOG.error("Key '{}' already deleted, but wasn't removed from "
+                        + "owned-keys set of service '{}'", key, name);
             }
           }
           container.clearOwnedKeys();
@@ -987,7 +1016,8 @@ public class ApplicationMaster {
           if (mayRestart && (service.getMaxRestarts() == -1
               || numRestarted < service.getMaxRestarts())) {
             numRestarted += 1;
-            LOG.info("RESTARTING: adding new container to replace " + container.getId());
+            LOG.info("RESTARTING: adding new container to replace {}.",
+                     container.getId());
             addContainer();
           }
 
@@ -1042,7 +1072,7 @@ public class ApplicationMaster {
       FinalApplicationStatus status = MsgUtils.readFinalStatus(req.getFinalStatus());
 
       // Shutdown everything but the grpc server
-      preshutdown(status, "Shutdown by user");
+      preshutdown(status, "Shutdown requested by user.");
 
       resp.onNext(MsgUtils.EMPTY);
       resp.onCompleted();
@@ -1114,7 +1144,8 @@ public class ApplicationMaster {
         return;
       }
 
-      services.get(service).finishContainer(instance, Model.Container.State.KILLED);
+      services.get(service).finishContainer(instance, Model.Container.State.KILLED,
+                                            "Killed by user request.");
       resp.onNext(MsgUtils.EMPTY);
       resp.onCompleted();
     }

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -132,7 +132,7 @@ public class ApplicationMaster {
 
     grpcServer = NettyServerBuilder.forPort(0)
         .sslContext(sslContext)
-        .addService(new MasterImpl())
+        .addService(new AppMasterImpl())
         .workerEventLoopGroup(eg)
         .bossEventLoopGroup(eg)
         .executor(executor)
@@ -999,7 +999,7 @@ public class ApplicationMaster {
     }
   }
 
-  class MasterImpl extends MasterGrpc.MasterImplBase {
+  class AppMasterImpl extends AppMasterGrpc.AppMasterImplBase {
 
     private boolean checkService(String name, StreamObserver<?> resp) {
       if (services.get(name) == null) {

--- a/java/src/main/java/com/anaconda/skein/Daemon.java
+++ b/java/src/main/java/com/anaconda/skein/Daemon.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.yarn.client.api.YarnClientApplication;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
 import org.apache.hadoop.yarn.util.ConverterUtils;
+import org.apache.log4j.Level;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -262,11 +263,13 @@ public class Daemon {
     String log4jConfig = (spec.getMaster().hasLogConfig()
                           ? "-Dlog4j.configuration=file:./log4j.properties "
                           : "");
+    Level logLevel = spec.getMaster().getLogLevel();
     List<String> commands = Arrays.asList(
         (Environment.JAVA_HOME.$$() + "/bin/java "
          + "-Xmx128M "
          + log4jConfig
-         + "com.anaconda.skein.ApplicationMaster "
+         + "-Dskein.log.level=" + logLevel
+         + " com.anaconda.skein.ApplicationMaster "
          + appDir + " " + appId.toString()
          + " >" + logdir + "/appmaster.log 2>&1"));
 

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -156,6 +156,18 @@ public class Model {
     public List<String> getUiUsers() { return uiUsers; }
   }
 
+  public static class Master {
+    private LocalResource logConfig;
+
+    public Master(LocalResource logConfig) {
+      this.logConfig = logConfig;
+    }
+
+    public void setLogConfig(LocalResource logConfig) { this.logConfig = logConfig; }
+    public LocalResource getLogConfig() { return this.logConfig; }
+    public boolean hasLogConfig() { return this.logConfig != null; }
+  }
+
   public static class ApplicationSpec {
     private String name;
     private String queue;
@@ -163,13 +175,14 @@ public class Model {
     private Set<String> tags;
     private List<Path> fileSystems;
     private Acls acls;
+    private Master master;
     private Map<String, Service> services;
 
     public ApplicationSpec() {}
 
     public ApplicationSpec(String name, String queue, int maxAttempts,
                            Set<String> tags, List<Path> fileSystems,
-                           Acls acls,
+                           Acls acls, Master master,
                            Map<String, Service> services) {
       this.name = name;
       this.queue = queue;
@@ -177,6 +190,7 @@ public class Model {
       this.tags = tags;
       this.fileSystems = fileSystems;
       this.acls = acls;
+      this.master = master;
       this.services = services;
     }
 
@@ -209,6 +223,9 @@ public class Model {
 
     public void setAcls(Acls acls) { this.acls = acls; }
     public Acls getAcls() { return this.acls; }
+
+    public void setMaster(Master master) { this.master = master; }
+    public Master getMaster() { return this.master; }
 
     public void setServices(Map<String, Service> services) { this.services = services; }
     public Map<String, Service> getServices() { return services; }

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -9,6 +9,7 @@ import org.apache.hadoop.yarn.api.records.NodeId;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.client.api.AMRMClient.ContainerRequest;
 import org.apache.hadoop.yarn.webapp.util.WebAppUtils;
+import org.apache.log4j.Level;
 
 import java.util.HashMap;
 import java.util.HashSet;
@@ -158,14 +159,19 @@ public class Model {
 
   public static class Master {
     private LocalResource logConfig;
+    private Level logLevel;
 
-    public Master(LocalResource logConfig) {
+    public Master(LocalResource logConfig, Level logLevel) {
       this.logConfig = logConfig;
+      this.logLevel = logLevel;
     }
 
     public void setLogConfig(LocalResource logConfig) { this.logConfig = logConfig; }
     public LocalResource getLogConfig() { return this.logConfig; }
     public boolean hasLogConfig() { return this.logConfig != null; }
+
+    public void setLogLevel(Level logLevel) { this.logLevel = logLevel; }
+    public Level getLogLevel() { return this.logLevel; }
   }
 
   public static class ApplicationSpec {

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -266,6 +266,7 @@ public class Model {
     private long finishTime;
     private ContainerRequest req;
     private Set<String> ownedKeys;
+    private String exitMessage;
 
     public Container() {}
 
@@ -337,6 +338,9 @@ public class Model {
 
     public void setFinishTime(long finishTime) { this.finishTime = finishTime; }
     public long getFinishTime() { return finishTime; }
+
+    public void setExitMessage(String diagnostics) { this.exitMessage = diagnostics; }
+    public String getExitMessage() { return exitMessage; }
 
     public void setContainerRequest(ContainerRequest req) { this.req = req; }
     public ContainerRequest popContainerRequest() {

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -319,6 +319,23 @@ public class MsgUtils {
     );
   }
 
+  public static Msg.Master writeMaster(Model.Master master) {
+    Msg.Master.Builder builder = Msg.Master.newBuilder();
+
+    if (master.hasLogConfig()) {
+      builder.setLogConfig(writeFile(master.getLogConfig()));
+    }
+    return builder.build();
+  }
+
+  public static Model.Master readMaster(Msg.Master master) {
+    LocalResource logConfig = null;
+    if (master.hasLogConfig()) {
+      logConfig = readFile(master.getLogConfig());
+    }
+    return new Model.Master(logConfig);
+  }
+
   public static Msg.ApplicationSpec writeApplicationSpec(Model.ApplicationSpec spec) {
     Msg.ApplicationSpec.Builder builder = Msg.ApplicationSpec.newBuilder()
         .setName(spec.getName())
@@ -326,6 +343,7 @@ public class MsgUtils {
         .setMaxAttempts(spec.getMaxAttempts())
         .addAllTags(spec.getTags())
         .setAcls(writeAcls(spec.getAcls()))
+        .setMaster(writeMaster(spec.getMaster()))
         .addAllFileSystems(Lists.transform(spec.getFileSystems(), Functions.toStringFunction()));
 
     for (Map.Entry<String, Model.Service> entry : spec.getServices().entrySet()) {
@@ -344,12 +362,14 @@ public class MsgUtils {
     for (int i = 0; i < spec.getFileSystemsCount(); i++) {
       fileSystems.add(new Path(spec.getFileSystems(i)));
     }
+
     return new Model.ApplicationSpec(spec.getName(),
                                      spec.getQueue(),
                                      spec.getMaxAttempts(),
                                      new HashSet<String>(spec.getTagsList()),
                                      fileSystems,
                                      readAcls(spec.getAcls()),
+                                     readMaster(spec.getMaster()),
                                      services);
   }
 

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -390,6 +390,10 @@ public class MsgUtils {
     if (nodeHttpAddress != null) {
       builder.setYarnNodeHttpAddress(nodeHttpAddress);
     }
+    String exitMessage = container.getExitMessage();
+    if (exitMessage != null) {
+      builder.setExitMessage(exitMessage);
+    }
     return builder.build();
   }
 
@@ -401,6 +405,7 @@ public class MsgUtils {
     out.setYarnContainerId(ContainerId.fromString(container.getYarnContainerId()));
     out.setStartTime(container.getStartTime());
     out.setFinishTime(container.getFinishTime());
+    out.setExitMessage(container.getExitMessage());
     return out;
   }
 }

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -14,6 +14,7 @@ import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
+import org.apache.log4j.Level;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -319,8 +320,53 @@ public class MsgUtils {
     );
   }
 
+  public static Msg.Log.Level writeLogLevel(Level logLevel) {
+    switch (logLevel.toInt()) {
+      case Level.INFO_INT:
+        return Msg.Log.Level.INFO;
+      case Level.ALL_INT:
+        return Msg.Log.Level.ALL;
+      case Level.TRACE_INT:
+        return Msg.Log.Level.TRACE;
+      case Level.DEBUG_INT:
+        return Msg.Log.Level.DEBUG;
+      case Level.WARN_INT:
+        return Msg.Log.Level.WARN;
+      case Level.ERROR_INT:
+        return Msg.Log.Level.ERROR;
+      case Level.FATAL_INT:
+        return Msg.Log.Level.FATAL;
+      case Level.OFF_INT:
+        return Msg.Log.Level.OFF;
+    }
+    return null; // appease the compiler, but can't get here
+  }
+
+  public static Level readLogLevel(Msg.Log.Level logLevel) {
+    switch (logLevel) {
+      case INFO:
+        return Level.INFO;
+      case ALL:
+        return Level.ALL;
+      case TRACE:
+        return Level.TRACE;
+      case DEBUG:
+        return Level.DEBUG;
+      case WARN:
+        return Level.WARN;
+      case ERROR:
+        return Level.ERROR;
+      case FATAL:
+        return Level.FATAL;
+      case OFF:
+        return Level.OFF;
+    }
+    return null; // appease the compiler, but can't get here
+  }
+
   public static Msg.Master writeMaster(Model.Master master) {
-    Msg.Master.Builder builder = Msg.Master.newBuilder();
+    Msg.Master.Builder builder = Msg.Master.newBuilder()
+        .setLogLevel(writeLogLevel(master.getLogLevel()));
 
     if (master.hasLogConfig()) {
       builder.setLogConfig(writeFile(master.getLogConfig()));
@@ -333,7 +379,8 @@ public class MsgUtils {
     if (master.hasLogConfig()) {
       logConfig = readFile(master.getLogConfig());
     }
-    return new Model.Master(logConfig);
+    Level logLevel = readLogLevel(master.getLogLevel());
+    return new Model.Master(logConfig, logLevel);
   }
 
   public static Msg.ApplicationSpec writeApplicationSpec(Model.ApplicationSpec spec) {

--- a/java/src/main/java/com/anaconda/skein/Utils.java
+++ b/java/src/main/java/com/anaconda/skein/Utils.java
@@ -23,6 +23,8 @@ import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 public class Utils {
   public static <T> T popfirst(Set<T> s) {
@@ -43,6 +45,18 @@ public class Utils {
       out[j * 2 + 1] = HEX[v & 0x0F];
     }
     return new String(out);
+  }
+
+  private static final String MEM_REGEX = "[0-9.]+ [KMG]B";
+  public static final Pattern EXCEEDED_PMEM_PATTERN =
+      Pattern.compile(MEM_REGEX + " of " + MEM_REGEX + " physical memory used");
+  public static final Pattern EXCEEDED_VMEM_PATTERN =
+      Pattern.compile(MEM_REGEX + " of " + MEM_REGEX + " virtual memory used");
+
+  public static String formatExceededMemMessage(String diagnostics, Pattern pattern) {
+    Matcher matcher = pattern.matcher(diagnostics);
+    return (matcher.find() ? matcher.group() :
+            "Container killed by YARN for exceeding memory limits");
   }
 
   public static final class CustomThreadFactory implements ThreadFactory {

--- a/java/src/main/java/com/anaconda/skein/WebUI.java
+++ b/java/src/main/java/com/anaconda/skein/WebUI.java
@@ -25,6 +25,8 @@ import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.ServletContextHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
+import org.eclipse.jetty.util.log.Log;
+import org.eclipse.jetty.util.log.Slf4jLog;
 import org.eclipse.jetty.util.resource.Resource;
 
 import java.io.IOException;
@@ -75,8 +77,8 @@ public class WebUI {
     writeLock = rwLock.writeLock();
     readLock = rwLock.readLock();
 
-    // Set the jetty log level
-    System.setProperty("org.eclipse.jetty.LEVEL", "WARN");
+    // Setup the jetty loggers
+    Log.setLog(new Slf4jLog());
 
     // Create the server
     server = new Server(port);

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -92,6 +92,11 @@ message Acls {
 }
 
 
+message Master {
+  File log_config = 1;
+}
+
+
 message ApplicationSpec {
   string name = 1;
   string queue = 2;
@@ -99,7 +104,8 @@ message ApplicationSpec {
   repeated string tags = 4;
   repeated string file_systems = 5;
   Acls acls = 6;
-  map<string, Service> services = 7;
+  Master master = 7;
+  map<string, Service> services = 8;
 }
 
 
@@ -187,7 +193,7 @@ message ApplicationsResponse {
 // Master only definitions
 
 
-service Master {
+service AppMaster {
   rpc shutdown (ShutdownRequest) returns (Empty);
 
   rpc GetRange (GetRangeRequest) returns (GetRangeResponse);

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -125,6 +125,7 @@ message Container {
   string yarn_node_http_address = 5;
   int64 start_time = 6;
   int64 finish_time = 7;
+  string exit_message = 8;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -92,8 +92,23 @@ message Acls {
 }
 
 
+message Log {
+  enum Level {
+    INFO = 0;
+    ALL = 1;
+    TRACE = 2;
+    DEBUG = 3;
+    WARN = 4;
+    ERROR = 5;
+    FATAL = 6;
+    OFF = 7;
+  }
+}
+
+
 message Master {
   File log_config = 1;
+  Log.Level log_level = 2;
 }
 
 

--- a/java/src/main/resources/log4j.properties
+++ b/java/src/main/resources/log4j.properties
@@ -1,10 +1,11 @@
-# Root logger option
-log4j.rootCategory=INFO, console
-log4j.logger.com.anaconda.skein.ApplicationMaster=INFO
-log4j.logger.com.anaconda.skein.WebUI=INFO
+skein.log.level=INFO
+log4j.rootLogger=${skein.log.level}, console
 
-# Redirect log messages to console
+# Console appender
 log4j.appender.console=org.apache.log4j.ConsoleAppender
 log4j.appender.console.Target=System.out
 log4j.appender.console.layout=org.apache.log4j.PatternLayout
-log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m:%n
+log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: %m%n
+
+# Quiet some noisier dependencies
+log4j.logger.com.anaconda.skein.shaded.org.eclipse.jetty=WARN

--- a/java/src/main/resources/log4j.properties
+++ b/java/src/main/resources/log4j.properties
@@ -1,5 +1,9 @@
+log4j.rootLogger=INFO, console
+
 skein.log.level=INFO
-log4j.rootLogger=${skein.log.level}, console
+log4j.logger.com.anaconda.skein.Daemon=${skein.log.level}
+log4j.logger.com.anaconda.skein.ApplicationMaster=${skein.log.level}
+log4j.logger.com.anaconda.skein.WebUI=${skein.log.level}
 
 # Console appender
 log4j.appender.console=org.apache.log4j.ConsoleAppender

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -4,7 +4,7 @@ from .exceptions import (SkeinError, ConnectionError, DaemonNotRunningError,
                          ApplicationNotRunningError, DaemonError,
                          ApplicationError)
 from .model import (ApplicationSpec, Service, File, Resources, FileType,
-                    FileVisibility, ACLs)
+                    FileVisibility, ACLs, Master)
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/skein/core.py
+++ b/skein/core.py
@@ -644,7 +644,7 @@ class ApplicationClient(_ClientBase):
     def __init__(self, address, app_id, security=None):
         self.address = address
         self.id = app_id
-        self._stub = proto.MasterStub(secure_channel(address, security))
+        self._stub = proto.AppMasterStub(secure_channel(address, security))
         self._shutdown = False
 
     def __repr__(self):

--- a/skein/model.py
+++ b/skein/model.py
@@ -998,15 +998,19 @@ class Container(ProtobufMessage):
         The start time, None if container has not started.
     finish_time : datetime
         The finish time, None if container has not finished.
+    exit_message : str
+        The diagnostic exit message for completed containers.
     """
     __slots__ = ('service_name', 'instance', '_state', 'yarn_container_id',
-                 'yarn_node_http_address', 'start_time', 'finish_time')
+                 'yarn_node_http_address', 'start_time', 'finish_time',
+                 'exit_message')
     _params = ('service_name', 'instance', 'state', 'yarn_container_id',
-               'yarn_node_http_address', 'start_time', 'finish_time')
+               'yarn_node_http_address', 'start_time', 'finish_time',
+               'exit_message')
     _protobuf_cls = _proto.Container
 
     def __init__(self, service_name, instance, state, yarn_container_id,
-                 yarn_node_http_address, start_time, finish_time):
+                 yarn_node_http_address, start_time, finish_time, exit_message):
         self.service_name = service_name
         self.instance = instance
         self.state = state
@@ -1014,6 +1018,7 @@ class Container(ProtobufMessage):
         self.yarn_node_http_address = yarn_node_http_address
         self.start_time = start_time
         self.finish_time = finish_time
+        self.exit_message = exit_message
 
         self._validate()
 
@@ -1037,6 +1042,7 @@ class Container(ProtobufMessage):
         self._check_is_type('yarn_node_http_address', string)
         self._check_is_type('start_time', datetime, nullable=True)
         self._check_is_type('finish_time', datetime, nullable=True)
+        self._check_is_type('exit_message', string)
 
     @property
     def id(self):
@@ -1070,4 +1076,5 @@ class Container(ProtobufMessage):
                    yarn_container_id=obj.yarn_container_id,
                    yarn_node_http_address=obj.yarn_node_http_address,
                    start_time=datetime_from_millis(obj.start_time),
-                   finish_time=datetime_from_millis(obj.finish_time))
+                   finish_time=datetime_from_millis(obj.finish_time),
+                   exit_message=obj.exit_message)

--- a/skein/objects.py
+++ b/skein/objects.py
@@ -87,6 +87,9 @@ class Enum(with_metaclass(EnumMeta)):
         return (self is other or
                 (isinstance(other, string) and self._value == other.upper()))
 
+    def __ne__(self, other):
+        return not (self == other)
+
     def __hash__(self):
         return hash(self._value)
 

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -1,10 +1,10 @@
 from __future__ import absolute_import
 
 from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
-                        Service, Acls, ApplicationSpec, ResourceUsageReport,
-                        ApplicationReport, Application, ApplicationsRequest,
-                        Url, ContainersRequest, Container, ContainerInstance,
-                        ScaleRequest, ShutdownRequest)
+                        Service, Acls, Master, ApplicationSpec,
+                        ResourceUsageReport, ApplicationReport, Application,
+                        ApplicationsRequest, Url, ContainersRequest, Container,
+                        ContainerInstance, ScaleRequest, ShutdownRequest)
 from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,
@@ -14,4 +14,4 @@ from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         WatchResponse)
 from .skein_pb2 import (Proxy, RemoveProxyRequest, UIInfoRequest, UIInfoResponse,
                         GetProxiesRequest, GetProxiesResponse)
-from .skein_pb2_grpc import DaemonStub, MasterStub
+from .skein_pb2_grpc import DaemonStub, AppMasterStub

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
-                        Service, Acls, Master, ApplicationSpec,
+                        Service, Acls, Log, Master, ApplicationSpec,
                         ResourceUsageReport, ApplicationReport, Application,
                         ApplicationsRequest, Url, ContainersRequest, Container,
                         ContainerInstance, ScaleRequest, ShutdownRequest)

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -76,13 +76,11 @@ def check_is_shutdown(client, app_id, status=None):
         assert client.application_report(app_id).final_status == status
 
 
-def wait_for_success(client, app_id, timeout=30):
+def wait_for_completion(client, app_id, timeout=30):
     while timeout:
-        state = client.application_report(app_id).state
-        if state == 'FINISHED':
-            return
-        elif state in ['FAILED', 'KILLED']:
-            assert False, "Application state = %r, expected 'FINISHED'" % state
+        final_status = client.application_report(app_id).final_status
+        if final_status != 'UNDEFINED':
+            return final_status
         time.sleep(0.1)
         timeout -= 0.1
     else:

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -328,6 +328,21 @@ def test_custom_log4j_properties(client, tmpdir):
     assert 'CUSTOM-LOG4J-SUCCEEDED' in logs
 
 
+def test_set_log_level(client):
+    service = skein.Service(resources=skein.Resources(memory=128, vcores=1),
+                            commands=['ls'])
+    spec = skein.ApplicationSpec(name="test_custom_log4j_properties",
+                                 queue="default",
+                                 master=skein.Master(log_level='debug'),
+                                 services={'service': service})
+
+    with run_application(client, spec=spec) as app:
+        assert wait_for_completion(client, app.id) == 'SUCCEEDED'
+
+    logs = get_logs(app.id)
+    assert 'DEBUG' in logs
+
+
 def test_memory_limit_exceeded(client):
     # Allocate noticeably more memory than the 128 MB limit
     service = skein.Service(

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -9,7 +9,7 @@ import pytest
 
 from skein.compatibility import UTC
 from skein.model import (ApplicationSpec, Service, Resources, File,
-                         ApplicationState, FinalStatus, FileType, ACLs,
+                         ApplicationState, FinalStatus, FileType, ACLs, Master,
                          Container, ApplicationReport, ResourceUsageReport)
 
 
@@ -168,6 +168,26 @@ def test_acls_invariants():
 
     with pytest.raises(TypeError):
         ACLs(view_users="*")
+
+
+def test_master():
+    m1 = Master()
+    m2 = Master(log_config='/test/path.properties')
+    check_specification_methods(m1, m2)
+
+
+def test_master_invariants():
+    with pytest.raises(TypeError):
+        Master(log_config=1)
+
+    # Strings are converted to File objects
+    m = Master('/test/path.properties')
+    assert isinstance(m.log_config, File)
+    assert m.log_config.type == 'file'
+
+    # Relative paths are converted
+    sol = 'file://%s' % os.path.join(os.getcwd(), 'foo/bar.properties')
+    assert Master(log_config='foo/bar.properties').log_config.source == sol
 
 
 def test_service():

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -10,7 +10,8 @@ import pytest
 from skein.compatibility import UTC
 from skein.model import (ApplicationSpec, Service, Resources, File,
                          ApplicationState, FinalStatus, FileType, ACLs, Master,
-                         Container, ApplicationReport, ResourceUsageReport)
+                         Container, ApplicationReport, ResourceUsageReport,
+                         LogLevel)
 
 
 def indent(s, n):
@@ -171,8 +172,8 @@ def test_acls_invariants():
 
 
 def test_master():
-    m1 = Master()
-    m2 = Master(log_config='/test/path.properties')
+    m1 = Master(log_level='info', log_config='/test/path.properties')
+    m2 = Master(log_level='debug')
     check_specification_methods(m1, m2)
 
 
@@ -181,13 +182,19 @@ def test_master_invariants():
         Master(log_config=1)
 
     # Strings are converted to File objects
-    m = Master('/test/path.properties')
+    m = Master(log_config='/test/path.properties')
     assert isinstance(m.log_config, File)
     assert m.log_config.type == 'file'
 
     # Relative paths are converted
     sol = 'file://%s' % os.path.join(os.getcwd(), 'foo/bar.properties')
     assert Master(log_config='foo/bar.properties').log_config.source == sol
+
+    # setter/getter
+    f = Master(log_level='debug')
+    assert f.log_level == LogLevel.DEBUG
+    f.log_level = 'info'
+    assert f.log_level == LogLevel.INFO
 
 
 def test_service():

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -400,7 +400,8 @@ def test_container():
     kwargs = dict(service_name="foo",
                   instance=0,
                   yarn_container_id='container_1528138529205_0038_01_000001',
-                  yarn_node_http_address='localhost:14420')
+                  yarn_node_http_address='localhost:14420',
+                  exit_message="")
 
     c = Container(state='RUNNING',
                   start_time=start,

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -372,6 +372,7 @@ def test_enums():
     assert ApplicationState.RUNNING is ApplicationState(ApplicationState.RUNNING)
     assert ApplicationState.RUNNING == ApplicationState.RUNNING
     assert ApplicationState.RUNNING == 'RUNNING'
+    assert not ApplicationState.RUNNING != 'RUNNING'
     assert ApplicationState.RUNNING == 'running'
     assert ApplicationState.RUNNING != 'foo'
 


### PR DESCRIPTION
This PR encompasses several changes:

- Adds a `master` top-level field to our configuration. This can be added to later to more deeply customize operation of the application master process, but for now contains only fields influencing logging configuration.
- Adds a `master.log_config` field, allowing for overriding the default `log4j.properties` file. This can be useful when debugging, as you can increase the amount of information from skein or its dependencies.
- Adds a `master.log_level` field, allowing for changing only the log level of skein (not its dependencies).
- Switching our logging to use `slf4j` instead of `log4j`. This has 2 benefits:
  - Ability to parametrize messages instead of manually constructing strings. This is both more legible and more performant when those messages are filtered, as the generation of the log string is avoided.
  - Allows jetty to use our logging configuration (this took forever to track down). This avoids jetty logging messages from mixing with ours, as their default logger is formatted differently and prints to stderr.
- Improves our logging messages. We now log more messages, and with more detail (this can still be improved). Some messages have been removed as useless, or moved to `debug` as they aren't as useful during normal operation.
- Adds an `exit_message` attribute to `Container` objects. This stores the exit message from finished containers. We can't get the logs from a container that failed due to its own operation, but for containers that were killed by yarn or skein, we can provide a useful message indicating the reason for the failure. Taken (with edits) from #66 (thanks @superbobry).

Documentation and tests have been provided for all of these changes.

Fixes #79, supersedes #66.