### PR TITLE
Add nodes, racks, and relax_locality

### DIFF
--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -838,12 +838,18 @@ public class ApplicationMaster {
 
     private synchronized void requestContainer(Model.Container container) {
       Priority priority = newPriority(this);
+      String[] nodes = (service.getNodes().isEmpty() ? null
+                        : service.getNodes().toArray(new String[0]));
+      String[] racks = (service.getRacks().isEmpty() ? null
+                        : service.getRacks().toArray(new String[0]));
+      boolean relaxLocality = ((nodes == null && racks == null) ? true
+                               : service.getRelaxLocality());
       ContainerRequest req = new ContainerRequest(
           service.getResources(),
-          null,
-          null,
+          nodes,
+          racks,
           priority,
-          true,
+          relaxLocality,
           Strings.emptyToNull(service.getNodeLabel()));
       container.setContainerRequest(req);
       rmClient.addContainerRequest(req);

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -35,6 +35,9 @@ public class Model {
   public static class Service {
     private int instances;
     private String nodeLabel;
+    private List<String> nodes;
+    private List<String> racks;
+    private boolean relaxLocality;
     private int maxRestarts;
     private Resource resources;
     private Map<String, LocalResource> localResources;
@@ -46,6 +49,9 @@ public class Model {
 
     public Service(int instances,
                    String nodeLabel,
+                   List<String> nodes,
+                   List<String> racks,
+                   boolean relaxLocality,
                    int maxRestarts,
                    Resource resources,
                    Map<String, LocalResource> localResources,
@@ -54,6 +60,9 @@ public class Model {
                    Set<String> depends) {
       this.instances = instances;
       this.nodeLabel = nodeLabel;
+      this.nodes = nodes;
+      this.racks = racks;
+      this.relaxLocality = relaxLocality;
       this.maxRestarts = maxRestarts;
       this.resources = resources;
       this.localResources = localResources;
@@ -79,6 +88,15 @@ public class Model {
 
     public void setNodeLabel(String nodeLabel) { this.nodeLabel = nodeLabel; }
     public String getNodeLabel() { return nodeLabel; }
+
+    public void setNodes(List<String> nodes) { this.nodes = nodes; }
+    public List<String> getNodes() { return nodes; }
+
+    public void setRacks(List<String> racks) { this.racks = racks; }
+    public List<String> getRacks() { return racks; }
+
+    public void setRelaxLocality(boolean relaxLocality) { this.relaxLocality = relaxLocality; }
+    public boolean getRelaxLocality() { return relaxLocality; }
 
     public void setMaxRestarts(int maxRestarts) { this.maxRestarts = maxRestarts; }
     public int getMaxRestarts() { return maxRestarts; }

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -272,6 +272,9 @@ public class MsgUtils {
     Msg.Service.Builder builder = Msg.Service.newBuilder()
         .setInstances(service.getInstances())
         .setNodeLabel(service.getNodeLabel())
+        .addAllNodes(service.getNodes())
+        .addAllRacks(service.getRacks())
+        .setRelaxLocality(service.getRelaxLocality())
         .setMaxRestarts(service.getMaxRestarts())
         .setResources(writeResources(service.getResources()))
         .putAllEnv(service.getEnv())
@@ -292,6 +295,9 @@ public class MsgUtils {
     return new Model.Service(
         service.getInstances(),
         service.getNodeLabel(),
+        new ArrayList<String>(service.getNodesList()),
+        new ArrayList<String>(service.getRacksList()),
+        service.getRelaxLocality(),
         service.getMaxRestarts(),
         readResources(service.getResources()),
         localResources,

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -74,12 +74,15 @@ message File {
 message Service {
   int32 instances = 1;
   string node_label = 2;
-  int32 max_restarts = 3;
-  Resources resources = 4;
-  map<string, File> files = 5;
-  map<string, string> env = 6;
-  repeated string commands = 7;
-  repeated string depends = 8;
+  repeated string nodes = 3;
+  repeated string racks = 4;
+  bool relax_locality = 5;
+  int32 max_restarts = 6;
+  Resources resources = 7;
+  map<string, File> files = 8;
+  map<string, string> env = 9;
+  repeated string commands = 10;
+  repeated string depends = 11;
 }
 
 

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -36,6 +36,9 @@ env:
 commands:
     - command 1
     - command 2
+nodes:
+    - worker.example.com
+relax_locality: true
 """
 
 app_spec = """\
@@ -259,7 +262,10 @@ def test_service():
     c = ['commands']
     s1 = Service(resources=r, commands=c,
                  node_label="testlabel",
-                 files={'file': File(source='/test/path')})
+                 files={'file': File(source='/test/path')},
+                 nodes=['worker.example.com'],
+                 racks=['rack1', 'rack2'],
+                 relax_locality=True)
     s2 = Service(resources=r, commands=c,
                  files={'file': File(source='/test/path', size=1024)})
     check_specification_methods(s1, s2)


### PR DESCRIPTION
Add `nodes`, `racks`, and `relax_locality` to the skein specification.
These are forwarded along for all container requests for the specified
service, and provide another way for services to restrict locality to a
subset of nodes.

- Added `nodes`, `racks`, and `relax_locality` to the specification
- Documented new fields
- Added tests for models and for functionality

Fixes #89.