### PR TITLE
Add ability to set progress for running application

### DIFF
--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -235,6 +235,8 @@ service AppMaster {
 
   rpc scale (ScaleRequest) returns (ContainersResponse);
 
+  rpc SetProgress (SetProgressRequest) returns (Empty);
+
   rpc AddProxy (Proxy) returns (Empty);
 
   rpc RemoveProxy (RemoveProxyRequest) returns (Empty);
@@ -424,6 +426,11 @@ message ContainersResponse {
 message ScaleRequest {
   string service_name = 1;
   int32 instances = 2;
+}
+
+
+message SetProgressRequest {
+  float progress = 1;
 }
 
 

--- a/skein/core.py
+++ b/skein/core.py
@@ -742,6 +742,27 @@ class ApplicationClient(_ClientBase):
         resp = self._call('scale', req)
         return [Container.from_protobuf(c) for c in resp.containers]
 
+    def set_progress(self, progress):
+        """Update the progress for this application.
+
+        For applications processing a fixed set of work it may be useful for
+        diagnostics to set the progress as the application processes.
+
+        Progress indicates job progression, and must be a float between 0 and
+        1. By default the progress is set at 0.1 for its duration, which is a
+        good default value for applications that don't know their progress,
+        (e.g. interactive applications).
+
+        Parameters
+        ----------
+        progress : float
+            The application progress, must be a value between 0 and 1.
+        """
+        if not (0 <= progress <= 1.0):
+            raise ValueError("progress must be between 0 and 1, got %.3f"
+                             % progress)
+        self._call('SetProgress', proto.SetProgressRequest(progress=progress))
+
     @classmethod
     def from_current(cls):
         """Create an application client from within a running container.

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -4,7 +4,8 @@ from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
                         Service, Acls, Log, Master, ApplicationSpec,
                         ResourceUsageReport, ApplicationReport, Application,
                         ApplicationsRequest, Url, ContainersRequest, Container,
-                        ContainerInstance, ScaleRequest, ShutdownRequest)
+                        ContainerInstance, ScaleRequest, ShutdownRequest,
+                        SetProgressRequest)
 from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -410,3 +410,20 @@ def test_node_locality(client, strict):
     assert service2.nodes == nodes
     assert service2.racks == racks
     assert service2.relax_locality == relax_locality
+
+
+def test_set_application_progress(client):
+    with run_application(client) as app:
+        app.set_progress(0.5)
+        # Give the allocate loop time to update
+        time.sleep(2)
+        report = client.application_report(app.id)
+        assert report.progress == 0.5
+
+        with pytest.raises(ValueError):
+            app.set_progress(-0.5)
+
+        with pytest.raises(ValueError):
+            app.set_progress(1.5)
+
+        app.shutdown()


### PR DESCRIPTION
Adds a `set_progress` method to an application, allows updating progress
reports for applications that have a known amount of work to do.

Fixes #88.