### PR TITLE
Fix wrapped kv methods

### DIFF
--- a/skein/kv.py
+++ b/skein/kv.py
@@ -803,7 +803,7 @@ def _register_op(return_type=None):
     """Register a key-value store operator"""
 
     def inner(cls):
-        @_wraps(cls)
+        @_wraps(cls.__init__)
         def method(self, *args, **kwargs):
             return self._apply_op(cls(*args, **kwargs))
 


### PR DESCRIPTION
Previously the wrapped kv methods doc signatures would miss the first
parameter (due to a missing `self` in the wrapped method signature). We
now wrap `cls.__init__` instead, fixing the issue.