### PR TITLE
Remove need for JAVA_HOME to be defined

### DIFF
--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -152,6 +152,21 @@ def test_client_errors_nicely_if_not_logged_in(security, not_logged_in):
             assert 'kinit' in str(exc.value)
 
 
+def test_client_starts_without_java_home(monkeypatch, tmpdir, security, kinit):
+    monkeypatch.delenv('JAVA_HOME', raising=False)
+
+    logpath = str(tmpdir.join("log.txt"))
+
+    with skein.Client(security=security, log=logpath) as client:
+        # do an operation to ensure everything is working
+        client.get_applications()
+
+    with open(logpath) as fil:
+        data = fil.read()
+        assert 'WARN' not in data
+        assert 'native-hadoop' not in data
+
+
 def test_client_set_log_level(security, kinit, tmpdir):
     logpath = str(tmpdir.join("log.txt"))
 


### PR DESCRIPTION
This was accidentally made required in #96. This makes it no longer required, and adds a test to ensure future behavior.