### PR TITLE
Add proxy-user support

### DIFF
--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -31,6 +31,13 @@ The name of the application. Optional, defaults to ``skein``.
 
 The queue to submit the application to. Optional, defaults to ``default``.
 
+``user``
+~~~~~~~~
+
+The username to submit the application as. Requires that the current user
+have permission to proxy as this username. Optional, defaults to the
+current user's username. In most cases the default is what you want.
+
 ``node_label``
 ~~~~~~~~~~~~~~
 

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -202,6 +202,7 @@ public class Model {
   public static class ApplicationSpec {
     private String name;
     private String queue;
+    private String user;
     private String nodeLabel;
     private int maxAttempts;
     private Set<String> tags;
@@ -212,12 +213,13 @@ public class Model {
 
     public ApplicationSpec() {}
 
-    public ApplicationSpec(String name, String queue, String nodeLabel, int maxAttempts,
-                           Set<String> tags, List<Path> fileSystems,
-                           Acls acls, Master master,
+    public ApplicationSpec(String name, String queue, String user,
+                           String nodeLabel, int maxAttempts, Set<String> tags,
+                           List<Path> fileSystems, Acls acls, Master master,
                            Map<String, Service> services) {
       this.name = name;
       this.queue = queue;
+      this.user = user;
       this.nodeLabel = nodeLabel;
       this.maxAttempts = maxAttempts;
       this.tags = tags;
@@ -243,6 +245,9 @@ public class Model {
 
     public void setQueue(String queue) { this.queue = queue; }
     public String getQueue() { return queue; }
+
+    public void setUser(String user) { this.user = user; }
+    public String getUser() { return user; }
 
     public void setNodeLabel(String nodeLabel) { this.nodeLabel = nodeLabel; }
     public String getNodeLabel() { return nodeLabel; }

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -395,6 +395,7 @@ public class MsgUtils {
     Msg.ApplicationSpec.Builder builder = Msg.ApplicationSpec.newBuilder()
         .setName(spec.getName())
         .setQueue(spec.getQueue())
+        .setUser(spec.getUser())
         .setNodeLabel(spec.getNodeLabel())
         .setMaxAttempts(spec.getMaxAttempts())
         .addAllTags(spec.getTags())
@@ -421,6 +422,7 @@ public class MsgUtils {
 
     return new Model.ApplicationSpec(spec.getName(),
                                      spec.getQueue(),
+                                     spec.getUser(),
                                      spec.getNodeLabel(),
                                      spec.getMaxAttempts(),
                                      new HashSet<String>(spec.getTagsList()),

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -119,13 +119,14 @@ message Master {
 message ApplicationSpec {
   string name = 1;
   string queue = 2;
-  string node_label = 3;
-  int32 max_attempts = 4;
-  repeated string tags = 5;
-  repeated string file_systems = 6;
-  Acls acls = 7;
-  Master master = 8;
-  map<string, Service> services = 9;
+  string user = 3;
+  string node_label = 4;
+  int32 max_attempts = 5;
+  repeated string tags = 6;
+  repeated string file_systems = 7;
+  Acls acls = 8;
+  Master master = 9;
+  map<string, Service> services = 10;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -193,7 +193,7 @@ service Daemon {
 
   rpc waitForStart (Application) returns (ApplicationReport);
 
-  rpc kill (Application) returns (Empty);
+  rpc kill (KillRequest) returns (Empty);
 }
 
 
@@ -209,6 +209,12 @@ message ApplicationsRequest {
 
 message ApplicationsResponse {
   repeated ApplicationReport reports = 1;
+}
+
+
+message KillRequest {
+  string id = 1;
+  string user = 2;
 }
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,7 +8,9 @@ ignore =
     # Comparing types instead of isinstance
     E721,
     # Ambiguous variable names
-    E741
+    E741,
+    # Allow breaks after binary operators
+    W504
 max-line-length = 90
 
 [versioneer]

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -279,9 +279,13 @@ def application_status(app_id):
 
 @subcommand(application.subs,
             'kill', 'Kill a Skein application',
-            app_id)
-def application_kill(app_id):
-    get_daemon().kill_application(app_id)
+            app_id,
+            arg('--user', default='', type=str,
+                help=('The user to kill the application as. Requires the '
+                      'current user to have permissions to proxy as ``user``. '
+                      'Default is the current user.')))
+def application_kill(app_id, user):
+    get_daemon().kill_application(app_id, user=user)
 
 
 @subcommand(application.subs,

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -389,7 +389,7 @@ def main(args=None):
         fail("Key %s is not set" % str(exc))
     except SkeinError as exc:
         fail(str(exc))
-    except Exception as exc:
+    except Exception:
         fail("Unexpected Error:\n%s" % traceback.format_exc(), prefix=False)
     sys.exit(0)
 

--- a/skein/core.py
+++ b/skein/core.py
@@ -650,15 +650,18 @@ class Client(_ClientBase):
         resp = self._call('getStatus', proto.Application(id=app_id))
         return ApplicationReport.from_protobuf(resp)
 
-    def kill_application(self, app_id):
+    def kill_application(self, app_id, user=""):
         """Kill an application.
 
         Parameters
         ----------
         app_id : str
             The id of the application to kill.
+        user : str, optional
+            The user to kill the application as. Requires the current user to
+            have permissions to proxy as ``user``. Default is the current user.
         """
-        self._call('kill', proto.Application(id=app_id))
+        self._call('kill', proto.KillRequest(id=app_id, user=user))
 
 
 class ApplicationClient(_ClientBase):

--- a/skein/model.py
+++ b/skein/model.py
@@ -781,6 +781,10 @@ class ApplicationSpec(Specification):
         The name of the application, defaults to 'skein'.
     queue : string, optional
         The queue to submit to. Defaults to the default queue.
+    user : string, optional
+        The user name to submit the application as. Requires that the
+        submitting user have permission to proxy as this user name. Default is
+        the submitter's user name.
     node_label : string, optional
         The node label expression to use when requesting containers for this
         application. Services can override this setting by specifying
@@ -801,16 +805,17 @@ class ApplicationSpec(Specification):
         application as failed. Note that this only considers failures of the
         application master during startup. Default is 1.
     """
-    __slots__ = ('services', 'name', 'queue', 'node_label', 'tags',
+    __slots__ = ('services', 'name', 'queue', 'user', 'node_label', 'tags',
                  'file_systems', 'acls', 'master', 'max_attempts')
     _protobuf_cls = _proto.ApplicationSpec
 
     def __init__(self, services=required, name='skein', queue='default',
-                 node_label='', tags=None, file_systems=None, acls=None, master=None,
-                 max_attempts=1):
+                 user='', node_label='', tags=None, file_systems=None,
+                 acls=None, master=None, max_attempts=1):
         self._assign_required('services', services)
         self.name = name
         self.queue = queue
+        self.user = user
         self.node_label = node_label
         self.tags = set() if tags is None else set(tags)
         self.file_systems = [] if file_systems is None else file_systems
@@ -826,6 +831,7 @@ class ApplicationSpec(Specification):
     def _validate(self):
         self._check_is_type('name', string)
         self._check_is_type('queue', string)
+        self._check_is_type('user', string)
         self._check_is_type('node_label', string)
         self._check_is_set_of('tags', string)
         self._check_is_list_of('file_systems', string)
@@ -880,6 +886,7 @@ class ApplicationSpec(Specification):
                     for k, v in obj.services.items()}
         return cls(name=obj.name,
                    queue=obj.queue,
+                   user=obj.user,
                    node_label=obj.node_label,
                    tags=set(obj.tags),
                    file_systems=list(obj.file_systems),

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -5,7 +5,7 @@ from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
                         ResourceUsageReport, ApplicationReport, Application,
                         ApplicationsRequest, Url, ContainersRequest, Container,
                         ContainerInstance, ScaleRequest, ShutdownRequest,
-                        SetProgressRequest)
+                        KillRequest, SetProgressRequest)
 from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,


### PR DESCRIPTION
Adds support for submitting applications to run as a username different than the submitting user's username. This requires that the submitter have proxy-user permissions to proxy as those accounts.