### PR TITLE
A few fixes to add MapR support

### DIFF
--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -1,6 +1,7 @@
 package com.anaconda.skein;
 
 import com.google.common.base.Functions;
+import com.google.common.base.Strings;
 import com.google.common.collect.Lists;
 
 import org.apache.hadoop.fs.Path;
@@ -235,7 +236,7 @@ public class MsgUtils {
   public static URL readUrl(Msg.Url url) {
     return URL.newInstance(
         url.getScheme(),
-        url.getHost(),
+        Strings.emptyToNull(url.getHost()),
         url.getPort() == 0 ? -1 : url.getPort(),
         url.getFile());
   }
@@ -243,7 +244,7 @@ public class MsgUtils {
   public static Msg.Url writeUrl(URL url) {
     return Msg.Url.newBuilder()
         .setScheme(url.getScheme())
-        .setHost(url.getHost())
+        .setHost(Strings.nullToEmpty(url.getHost()))
         .setPort(url.getPort())
         .setFile(url.getFile())
         .build();

--- a/java/src/main/resources/log4j.properties
+++ b/java/src/main/resources/log4j.properties
@@ -13,3 +13,4 @@ log4j.appender.console.layout.ConversionPattern=%d{yy/MM/dd HH:mm:ss} %p %c{2}: 
 
 # Quiet some noisier dependencies
 log4j.logger.com.anaconda.skein.shaded.org.eclipse.jetty=WARN
+log4j.logger.org.apache.zookeeper=WARN


### PR DESCRIPTION
- MapR filesystem doesn't have a host in the normalized form, was leading to a null-pointer exception. We now check for this and handle it properly.
- ZooKeeper logging is incredibly verbose, turn it down to WARN by default.