### PR TITLE
 Make security configurable per application 

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -4,13 +4,6 @@ API Docs
 .. currentmodule:: skein
 
 
-Security
---------
-
-.. autoclass:: Security
-    :members:
-
-
 Client
 -------
 
@@ -159,6 +152,10 @@ Application Specification
     :inherited-members:
 
 .. autoclass:: Master
+    :members:
+    :inherited-members:
+
+.. autoclass:: Security
     :members:
     :inherited-members:
 

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -159,6 +159,11 @@ Supported subfields are:
   or on a remote filesystem. If not provided, a default logging configuration
   is used. See the `Log4j documentation <https://logging.apache.org/log4j/1.2/>`__
   for more information.
+- ``security``: security configuration for the application master. By default
+  the application master will use the same security credentials as the daemon
+  that launched it. To override, provide a mapping of specifying the locations
+  of ``cert_file`` and ``key_file``. See the :class:`Security` docstring for
+  more information.
 
 **Example**
 

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -9,7 +9,8 @@
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <grpc.version>1.11.0</grpc.version>
+    <grpc.version>1.16.0</grpc.version>
+    <boringssl.version>2.0.17.Final</boringssl.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
     <hadoopVersion>2.7.2</hadoopVersion>
   </properties>
@@ -175,7 +176,7 @@
     <dependency>
       <groupId>io.netty</groupId>
       <artifactId>netty-tcnative-boringssl-static</artifactId>
-      <version>2.0.7.Final</version>
+      <version>${boringssl.version}</version>
     </dependency>
 
     <dependency>

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -373,13 +373,63 @@ public class MsgUtils {
     return null; // appease the compiler, but can't get here
   }
 
+  public static Msg.Security writeSecurity(Model.Security security) {
+    Msg.Security.Builder builder = Msg.Security.newBuilder();
+
+    if (security.getCertBytes() != null) {
+      builder.setCertBytes(security.getCertBytes());
+    } else if (security.getCertFile() != null) {
+      builder.setCertFile(writeFile(security.getCertFile()));
+    }
+
+    if (security.getKeyBytes() != null) {
+      builder.setKeyBytes(security.getKeyBytes());
+    } else if (security.getKeyFile() != null) {
+      builder.setKeyFile(writeFile(security.getKeyFile()));
+    }
+
+    return builder.build();
+  }
+
+  public static Model.Security readSecurity(Msg.Security security) {
+    Model.Security result = new Model.Security();
+
+    switch (security.getCertCase()) {
+      case CERT_BYTES:
+        result.setCertBytes(security.getCertBytes());
+        break;
+      case CERT_FILE:
+        result.setCertFile(readFile(security.getCertFile()));
+        break;
+      case CERT_NOT_SET:
+        break;
+    }
+
+    switch (security.getKeyCase()) {
+      case KEY_BYTES:
+        result.setKeyBytes(security.getKeyBytes());
+        break;
+      case KEY_FILE:
+        result.setKeyFile(readFile(security.getKeyFile()));
+        break;
+      case KEY_NOT_SET:
+        break;
+    }
+    return result;
+  }
+
   public static Msg.Master writeMaster(Model.Master master) {
     Msg.Master.Builder builder = Msg.Master.newBuilder()
         .setLogLevel(writeLogLevel(master.getLogLevel()));
 
+    if (master.hasSecurity()) {
+      builder.setSecurity(writeSecurity(master.getSecurity()));
+    }
+
     if (master.hasLogConfig()) {
       builder.setLogConfig(writeFile(master.getLogConfig()));
     }
+
     return builder.build();
   }
 
@@ -388,8 +438,12 @@ public class MsgUtils {
     if (master.hasLogConfig()) {
       logConfig = readFile(master.getLogConfig());
     }
+    Model.Security security = null;
+    if (master.hasSecurity()) {
+      security = readSecurity(master.getSecurity());
+    }
     Level logLevel = readLogLevel(master.getLogLevel());
-    return new Model.Master(logConfig, logLevel);
+    return new Model.Master(logConfig, logLevel, security);
   }
 
   public static Msg.ApplicationSpec writeApplicationSpec(Model.ApplicationSpec spec) {

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -110,9 +110,22 @@ message Log {
 }
 
 
+message Security {
+  oneof cert {
+    File cert_file = 1;
+    bytes cert_bytes = 2;
+  }
+  oneof key {
+    File key_file = 3;
+    bytes key_bytes = 4;
+  }
+}
+
+
 message Master {
   File log_config = 1;
   Log.Level log_level = 2;
+  Security security = 3;
 }
 
 

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -1,10 +1,10 @@
 from . import kv
-from .core import Client, ApplicationClient, Security, properties
+from .core import Client, ApplicationClient, properties
 from .exceptions import (SkeinError, ConnectionError, DaemonNotRunningError,
                          ApplicationNotRunningError, DaemonError,
                          ApplicationError)
-from .model import (ApplicationSpec, Service, File, Resources, FileType,
-                    FileVisibility, ACLs, Master)
+from .model import (Security, ApplicationSpec, Service, File, Resources,
+                    FileType, FileVisibility, ACLs, Master)
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -6,10 +6,10 @@ import sys
 import traceback
 
 from . import __version__
-from .core import Client, ApplicationClient, Security
+from .core import Client, ApplicationClient, properties
 from .compatibility import read_stdin_bytes, write_stdout_bytes
 from .exceptions import context, SkeinError, DaemonNotRunningError
-from .model import ApplicationSpec, ContainerState, ApplicationState
+from .model import ApplicationSpec, ContainerState, ApplicationState, Security
 from .utils import format_table, humanize_timedelta
 
 
@@ -375,7 +375,8 @@ config = node(entry_subs, 'config', 'Manage skein configuration')
             arg('--force', '-f', action='store_true',
                 help='Overwrite existing configuration'))
 def config_gencerts(force=False):
-    Security.from_new_directory(force=force)
+    sec = Security.new_credentials()
+    sec.to_directory(directory=properties.config_dir, force=force)
 
 
 def main(args=None):

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
-                        Service, Acls, Log, Master, ApplicationSpec,
+                        Service, Acls, Log, Master, Security, ApplicationSpec,
                         ResourceUsageReport, ApplicationReport, Application,
                         ApplicationsRequest, Url, ContainersRequest, Container,
                         ContainerInstance, ScaleRequest, ShutdownRequest,

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -29,7 +29,8 @@ def skein_config(tmpdir_factory):
 
 @pytest.fixture(scope="session")
 def security(tmpdir_factory):
-    return skein.Security.from_new_directory(str(tmpdir_factory.mktemp('security')))
+    path = str(tmpdir_factory.mktemp('security'))
+    return skein.Security.new_credentials().to_directory(path)
 
 
 @pytest.fixture(scope="session")

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -117,11 +117,8 @@ def test_cli_config_gencerts(capsys, skein_config):
     assert not out
 
     security = skein.Security.from_directory(skein_config)
-    with open(security.cert_path) as f:
-        cert = f.read()
-
-    with open(security.key_path) as f:
-        key = f.read()
+    cert = security._get_bytes('cert')
+    key = security._get_bytes('key')
 
     # Running again fails due to missing --force
     run_command('config gencerts', error=True)
@@ -131,11 +128,8 @@ def test_cli_config_gencerts(capsys, skein_config):
     assert 'already exists' in err
 
     # files aren't overwritten on error
-    with open(security.cert_path) as f:
-        cert2 = f.read()
-
-    with open(security.key_path) as f:
-        key2 = f.read()
+    cert2 = security._get_bytes('cert')
+    key2 = security._get_bytes('key')
 
     assert cert == cert2
     assert key == key2
@@ -147,11 +141,8 @@ def test_cli_config_gencerts(capsys, skein_config):
     assert not err
 
     # Files are overwritten
-    with open(security.cert_path) as f:
-        cert2 = f.read()
-
-    with open(security.key_path) as f:
-        key2 = f.read()
+    cert2 = security._get_bytes('cert')
+    key2 = security._get_bytes('key')
 
     assert cert != cert2
     assert key != key2

--- a/skein/utils.py
+++ b/skein/utils.py
@@ -1,8 +1,30 @@
 from __future__ import print_function, division, absolute_import
 
+import os
+from contextlib import contextmanager
 from datetime import datetime, timedelta
 
 from .compatibility import unicode, UTC
+
+
+@contextmanager
+def grpc_fork_support_disabled():
+    """Temporarily disable fork support in gRPC.
+
+    Fork + exec has always been supported, but the recent fork handling code in
+    gRPC (>= 1.15) results in extraneous error logs currently. For now we
+    explicitly disable fork support for gRPC clients we create.
+    """
+    key = 'GRPC_ENABLE_FORK_SUPPORT'
+    try:
+        os.environ[key] = '0'
+        yield
+    finally:
+        del os.environ[key]
+
+
+def xor(a, b):
+    return bool(a) != bool(b)
 
 
 def ensure_unicode(x):


### PR DESCRIPTION
Allows specifying security configuration as part of the application spec. TLS credentials can be specified either as file locations or as raw bytestrings. This allows for launching applications with differing TLS credentials from the same originating daemon.

Also quiets a noisy extraneous log message from grpc >= 1.15 when using fork + exec. This noisy extraneous message should be fixed in a future release of grpc (1.17?), but for now it's better to just quiet it ourselves.

Fixes #102.