### PR TITLE
Import abstract classes from collections.abc

### DIFF
--- a/skein/compatibility.py
+++ b/skein/compatibility.py
@@ -13,6 +13,7 @@ if PY2:
     from math import ceil as _ceil
     from urlparse import urlparse, urlsplit  # noqa
     from Queue import Queue  # noqa
+    from collections import Mapping, MutableMapping  # noqa
     unicode = unicode  # noqa
     string = basestring  # noqa
     integer = (int, long)  # noqa
@@ -53,6 +54,7 @@ else:
     from urllib.parse import urlparse, urlsplit  # noqa
     from os import makedirs  # noqa
     from queue import Queue  # noqa
+    from collections.abc import Mapping, MutableMapping  # noqa
     unicode = str
     string = str
     integer = int

--- a/skein/core.py
+++ b/skein/core.py
@@ -7,13 +7,12 @@ import signal
 import socket
 import struct
 import subprocess
-from collections import Mapping
 from contextlib import closing
 
 import grpc
 
 from . import proto
-from .compatibility import PY2, makedirs, isidentifier
+from .compatibility import PY2, makedirs, isidentifier, Mapping
 from .exceptions import (context, FileNotFoundError, ConnectionError,
                          TimeoutError, ApplicationNotRunningError,
                          ApplicationError, DaemonNotRunningError, DaemonError)

--- a/skein/kv.py
+++ b/skein/kv.py
@@ -7,8 +7,6 @@ import threading as _threading
 import weakref as _weakref
 from collections import (namedtuple as _namedtuple,
                          deque as _deque,
-                         MutableMapping as _MutableMapping,
-                         Mapping as _Mapping,
                          OrderedDict as _OrderedDict)
 from functools import wraps as _wraps
 
@@ -17,7 +15,9 @@ import grpc as _grpc
 from . import proto as _proto
 from .compatibility import (bind_method as _bind_method,
                             Queue as _Queue,
-                            string as _string)
+                            string as _string,
+                            Mapping as _Mapping,
+                            MutableMapping as _MutableMapping)
 from .exceptions import (ApplicationError as _ApplicationError,
                          ConnectionError as _ConnectionError)
 from .model import (

--- a/skein/test/test_kv.py
+++ b/skein/test/test_kv.py
@@ -6,11 +6,12 @@ import sys
 import threading
 import time
 import weakref
-from collections import MutableMapping, OrderedDict
+from collections import OrderedDict
 
 import pytest
 
 from skein import kv
+from skein.compatibility import MutableMapping
 from skein.exceptions import ConnectionError
 from skein.test.conftest import run_application
 


### PR DESCRIPTION
The abstract base classes in `collections` were moved to
`collections.abc` in Python 3.3, but they were still available to import
from `collections`. Python 3.7 added deprecation warnings when the
instances in `collections` are used, and they will be fully removed from
`collections` in Python 3.8.