### PR TITLE
Reduce size of jar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -47,11 +47,51 @@
             </goals>
             <configuration>
               <minimizeJar>true</minimizeJar>
-              <transformers>
-                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>com.anaconda.skein.Daemon</mainClass>
-                </transformer>
-              </transformers>
+
+              <artifactSet>
+                <excludes>
+                  <exclude>org.webjars:popper.js</exclude>
+                </excludes>
+              </artifactSet>
+
+              <filters>
+                <filter>
+                  <artifact>*:*</artifact>
+                  <excludes>
+                    <exclude>META-INF/maven/**</exclude>
+                    <exclude>google/**</exclude>
+                    <exclude>skein.proto</exclude>
+                  </excludes>
+                </filter>
+                <filter>
+                  <artifact>org.webjars.bower:open-iconic</artifact>
+                  <includes>
+                    <include>META-INF/resources/webjars/open-iconic/1.1.1/font/fonts/*</include>
+                    <include>META-INF/resources/webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>org.webjars:jquery</artifact>
+                  <includes>
+                    <include>META-INF/resources/webjars/jquery/3.0.0/jquery.min.js</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>org.webjars:bootstrap</artifact>
+                  <includes>
+                    <include>META-INF/resources/webjars/bootstrap/4.1.1/css/bootstrap.min.css</include>
+                    <include>META-INF/resources/webjars/bootstrap/4.1.1/js/bootstrap.bundle.min.js</include>
+                  </includes>
+                </filter>
+                <filter>
+                  <artifact>io.netty:netty-tcnative-boringssl-static</artifact>
+                  <excludes>
+                    <exclude>META-INF/native/*.dll</exclude>
+                    <exclude>META-INF/native/*.jnilib</exclude>
+                  </excludes>
+                </filter>
+              </filters>
+
               <relocations>
                 <relocation>
                   <pattern>com.google</pattern>
@@ -225,6 +265,7 @@
       <groupId>log4j</groupId>
       <artifactId>log4j</artifactId>
       <version>1.2.17</version>
+      <scope>provided</scope>
     </dependency>
 
     <dependency>

--- a/java/src/main/resources/kv.mustache.html
+++ b/java/src/main/resources/kv.mustache.html
@@ -88,6 +88,6 @@
     </div>
 
     <script src="webjars/jquery/3.0.0/jquery.min.js"></script>
-    <script src="webjars/bootstrap/4.1.1/js/bootstrap.min.js"></script>
+    <script src="webjars/bootstrap/4.1.1/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>

--- a/java/src/main/resources/services.mustache.html
+++ b/java/src/main/resources/services.mustache.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
     <link rel="stylesheet" href="webjars/bootstrap/4.1.1/css/bootstrap.min.css">
-    <link rel="stylesheet" href="webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.css">
+    <link rel="stylesheet" href="webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css">
 
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
     <link rel="icon" type="image/png" sizes="16x16" href="favicon-16x16.png">
@@ -179,7 +179,7 @@
     </div>
 
     <script src="webjars/jquery/3.0.0/jquery.min.js"></script>
-    <script src="webjars/bootstrap/4.1.1/js/bootstrap.min.js"></script>
+    <script src="webjars/bootstrap/4.1.1/js/bootstrap.bundle.min.js"></script>
     <script>
       $(document).ready(function () {
         // Need to try session storage, as it may exist but fail in private mode


### PR DESCRIPTION
This applies some filters on what's included in the jar to reduce the overall jar size. We filter out:

- Web resources we don't actually need
- Some java packages that are unnecessary
- Native libraries for non-linux systems (we don't currently work on windows anyway, which isn't a problem for most hadoop installs)
- The whole maven folder, as we're not a package
- All the *.proto files, as these aren't needed at runtime

We also make log4j a provided dependency, which should be true as long as hadoop doesn't change things.

These changes combined remove around 5 MB from the overall jar, bringing us from ~13 MiB to ~8 MiB.

Fixes #106.