### PR TITLE
Use Protobuf Lite

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -94,8 +94,16 @@
 
               <relocations>
                 <relocation>
+                  <pattern>javax.*</pattern>
+                  <shadedPattern>com.anaconda.skein.shaded.javax</shadedPattern>
+                </relocation>
+                <relocation>
                   <pattern>com.google</pattern>
                   <shadedPattern>com.anaconda.skein.shaded.com.google</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.checkerframework</pattern>
+                  <shadedPattern>com.anaconda.skein.shaded.org.checkerframework</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>io.netty</pattern>
@@ -112,6 +120,14 @@
                 <relocation>
                   <pattern>io.grpc</pattern>
                   <shadedPattern>com.anaconda.skein.shaded.io.grpc</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>io.opencensus</pattern>
+                  <shadedPattern>com.anaconda.skein.shaded.io.opencensus</shadedPattern>
+                </relocation>
+                <relocation>
+                  <pattern>org.codehaus</pattern>
+                  <shadedPattern>com.anaconda.skein.shaded.org.codehaus</shadedPattern>
                 </relocation>
                 <relocation>
                   <pattern>META-INF/native/libnetty</pattern>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -132,18 +132,56 @@
         <artifactId>protobuf-maven-plugin</artifactId>
         <version>0.5.1</version>
         <configuration>
-          <protocArtifact>com.google.protobuf:protoc:3.5.1-1:exe:${os.detected.classifier}</protocArtifact>
-          <pluginId>grpc-java</pluginId>
-          <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+          <protocArtifact>com.google.protobuf:protoc:3.0.0:exe:${os.detected.classifier}</protocArtifact>
         </configuration>
         <executions>
           <execution>
+            <id>protoc-java</id>
             <goals>
-            <goal>compile</goal>
-            <goal>compile-custom</goal>
+              <goal>compile</goal>
+            </goals>
+            <configuration>
+              <pluginId>lite</pluginId>
+              <pluginArtifact>com.google.protobuf:protoc-gen-javalite:3.0.0</pluginArtifact>
+            </configuration>
+          </execution>
+          <execution>
+            <id>protoc-grpc</id>
+            <goals>
+              <goal>compile-custom</goal>
+            </goals>
+            <configuration>
+              <pluginId>grpc-java</pluginId>
+              <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
+              <pluginParameter>lite</pluginParameter>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>com.google.code.maven-replacer-plugin</groupId>
+        <artifactId>replacer</artifactId>
+        <version>1.5.3</version>
+        <executions>
+          <execution>
+            <phase>process-sources</phase>
+            <goals>
+              <goal>replace</goal>
             </goals>
           </execution>
         </executions>
+        <configuration>
+          <includes>
+            <include>${basedir}/target/generated-sources/protobuf/java/com/anaconda/skein/Msg.java</include>
+          </includes>
+          <replacements>
+            <replacement>
+              <token>\npublic final class</token>
+              <value>@SuppressWarnings("unchecked") public final class</value>
+            </replacement>
+          </replacements>
+        </configuration>
       </plugin>
 
       <plugin>
@@ -203,7 +241,7 @@
 
     <dependency>
       <groupId>io.grpc</groupId>
-      <artifactId>grpc-protobuf</artifactId>
+      <artifactId>grpc-protobuf-lite</artifactId>
       <version>${grpc.version}</version>
     </dependency>
 

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -1244,7 +1244,7 @@ public class ApplicationMaster {
               break;
             case KEYS:
               for (String key : selection.keySet()) {
-                builder.addResultBuilder().setKey(key);
+                builder.addResult(Msg.KeyValue.newBuilder().setKey(key));
               }
               break;
             case NONE:
@@ -1304,7 +1304,7 @@ public class ApplicationMaster {
               break;
             case KEYS:
               for (String key : selection.keySet()) {
-                builder.addResultBuilder().setKey(key);
+                builder.addResult(Msg.KeyValue.newBuilder().setKey(key));
               }
               break;
             case NONE:
@@ -1333,7 +1333,7 @@ public class ApplicationMaster {
                               iEnd == null || iEnd.compareTo(lastKey) >= 0);
 
               for (String key : iSelection.keySet()) {
-                wrBuilder.addEventBuilder().setKey(key);
+                wrBuilder.addEvent(Msg.KeyValue.newBuilder().setKey(key));
               }
               item.getValue().sendMsg(watchId, wrBuilder.build());
             }
@@ -1601,16 +1601,16 @@ public class ApplicationMaster {
         for (Msg.OpRequest op : ops) {
           switch (op.getRequestCase()) {
             case PUT_KEY:
-              builder.addResultBuilder()
-                     .setPutKey(evalPutKey(op.getPutKey()));
+              builder.addResult(Msg.OpResponse.newBuilder()
+                     .setPutKey(evalPutKey(op.getPutKey())));
               break;
             case GET_RANGE:
-              builder.addResultBuilder()
-                     .setGetRange(evalGetRange(op.getGetRange()));
+              builder.addResult(Msg.OpResponse.newBuilder()
+                     .setGetRange(evalGetRange(op.getGetRange())));
               break;
             case DELETE_RANGE:
-              builder.addResultBuilder()
-                     .setDeleteRange(evalDeleteRange(op.getDeleteRange()));
+              builder.addResult(Msg.OpResponse.newBuilder()
+                     .setDeleteRange(evalDeleteRange(op.getDeleteRange())));
               break;
             default:
               break;

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -2,6 +2,7 @@ syntax = "proto3";
 
 option java_package = "com.anaconda.skein";
 option java_outer_classname = "Msg";
+option optimize_for = LITE_RUNTIME;
 
 
 package skein;


### PR DESCRIPTION
This shaves another 1 MiB off the final jar size (down to 7.4 MiB). Since *most* applications won't be sending many many messages, the performance hit here should be minimal.

At this point the bulk of the jar is guava. I tried to use proguard to slim this down, but couldn't (easily) figure out how to accomplish this. For now I'm ok with the current jar size.

Continues to address #106.