### PR TITLE
Rename daemon to driver

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -189,13 +189,13 @@ Exceptions
 .. autoexception:: ConnectionError
     :show-inheritance:
 
-.. autoexception:: DaemonNotRunningError
+.. autoexception:: DriverNotRunningError
     :show-inheritance:
 
 .. autoexception:: ApplicationNotRunningError
     :show-inheritance:
 
-.. autoexception:: DaemonError
+.. autoexception:: DriverError
     :show-inheritance:
 
 .. autoexception:: ApplicationError

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -10,6 +10,7 @@ Client
 .. autoclass:: Client
     :members:
     :inherited-members:
+    :exclude-members: start_global_daemon, stop_global_daemon
 
 
 Application Client

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -6,6 +6,8 @@ Upcoming Release
 
 - Support login via keytab, allowing for long-running services (:pr:`115`,
   :issue:`103`)
+- Rename ``daemon`` to ``driver`` everywhere, deprecating old methods/classes
+  (:pr:`116`)
 
 Version 0.4.1 (December 7, 2018)
 --------------------------------

--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -86,13 +86,13 @@ information. This can be accomplished two different ways:
       log_config: path/to/my/log4j.properties
 
 
-Configuring Logging in the Client Daemon
+Configuring Logging in the Client Driver
 ----------------------------------------
 
-The :class:`skein.Client` uses a Java daemon process to communicate with
+The :class:`skein.Client` uses a Java driver process to communicate with
 services like YARN and HDFS. If you find issues in communicating with these
 services (submitting, querying, or killing applications), it may be useful to
-increase logging verbosity for the skein daemon process (``debug`` is a good
+increase logging verbosity for the skein driver process (``debug`` is a good
 option). There are a few ways to do this:
 
 - Using the ``log_level`` keyword when creating a :class:`skein.Client`.
@@ -100,24 +100,24 @@ option). There are a few ways to do this:
 - Setting the ``SKEIN_LOG_LEVEL`` environment variable (e.g.
   ``SKEIN_LOG_LEVEL=DEBUG``).
 
-- Using the ``--log-level`` flag when starting a persistent daemon using the
-  `CLI <cli.html>`__ (e.g.  ``skein daemon start --log-level debug``).
+- Using the ``--log-level`` flag when starting a persistent driver using the
+  `CLI <cli.html>`__ (e.g.  ``skein driver start --log-level debug``).
 
 Additionally, you may want to log to a file instead of to the terminal. There
 are also a few ways to do this:
 
 - Using the ``log`` keyword when creating a :class:`skein.Client`.
 
-- Using the ``--log`` flag when starting a persistent daemon using the `CLI
+- Using the ``--log`` flag when starting a persistent driver using the `CLI
   <cli.html>`__.
 
 **Example**
 
 .. code-block:: python
 
-    # Create a client, logging to `daemon.log` with "debug" log level
+    # Create a client, logging to `driver.log` with "debug" log level
     import skein
-    client = skein.Client(log_level='debug', log='daemon.log')
+    client = skein.Client(log_level='debug', log='driver.log')
 
 
 Start a Remote IPython Kernel on the Container

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -22,30 +22,30 @@ make sure you have an active ticket-granting-ticket before continuing:
     $ kinit
 
 
-.. _quickstart-skein-daemon:
+.. _quickstart-skein-driver:
 
 
-Start the Skein Daemon (optional)
+Start the Skein Driver (optional)
 ---------------------------------
 
-To communicate with the YARN Resource manager, Skein uses a background daemon
+To communicate with the YARN Resource manager, Skein uses a background driver
 process written in Java. Since this process can be slow to start, sometimes it
 can be nice to start it once and have it persist through all CLI calls. This
 may look like:
 
-1. Start the Skein daemon
+1. Start the Skein driver
 2. Run yarn application/applications
-3. Shut down the Skein daemon
+3. Shut down the Skein driver
 
-To do this from the command-line, use `skein daemon start
-<cli.html#skein-daemon-start>`__:
+To do this from the command-line, use `skein driver start
+<cli.html#skein-driver-start>`__:
 
 .. code::
 
-    $ skein daemon start
+    $ skein driver start
     localhost:12345
 
-Note that if you don't start the daemon process, one will be started for you,
+Note that if you don't start the driver process, one will be started for you,
 but not persisted between calls.
 
 
@@ -196,17 +196,17 @@ use the `skein application kill <cli.html#skein-application-kill>`__ command:
     application_1526497750451_0009    hello_world    KILLED    KILLED    0             0         0
 
 
-Stop the Skein Daemon (optional)
+Stop the Skein Driver (optional)
 --------------------------------
 
-If you started the Daemon process (see `Start the Skein Daemon (optional)`_
+If you started the Driver process (see `Start the Skein Driver (optional)`_
 above), you'll probably want to shut it down when you're done.  This isn't
-strictly necessary (the daemon can run for long periods), but helps keep
+strictly necessary (the driver can run for long periods), but helps keep
 resource usage on the edge node low.
 
-To do this from the command-line, use `skein daemon stop
-<cli.html#skein-daemon-stop>`__.
+To do this from the command-line, use `skein driver stop
+<cli.html#skein-driver-stop>`__.
 
 .. code::
 
-    $ skein daemon stop
+    $ skein driver stop

--- a/docs/source/recipes-ipython-kernel.rst
+++ b/docs/source/recipes-ipython-kernel.rst
@@ -35,10 +35,10 @@ Kinit (optional)
 See :ref:`quickstart-kinit`.
 
 
-Start the Skein Daemon (optional)
+Start the Skein Driver (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See :ref:`quickstart-skein-daemon`.
+See :ref:`quickstart-skein-driver`.
 
 
 Package the Python Environment

--- a/docs/source/recipes-jupyter-notebook.rst
+++ b/docs/source/recipes-jupyter-notebook.rst
@@ -45,10 +45,10 @@ Kinit (optional)
 See :ref:`quickstart-kinit`.
 
 
-Start the Skein Daemon (optional)
+Start the Skein Driver (optional)
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-See :ref:`quickstart-skein-daemon`.
+See :ref:`quickstart-skein-driver`.
 
 
 Package the Python Environment

--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -160,7 +160,7 @@ Supported subfields are:
   is used. See the `Log4j documentation <https://logging.apache.org/log4j/1.2/>`__
   for more information.
 - ``security``: security configuration for the application master. By default
-  the application master will use the same security credentials as the daemon
+  the application master will use the same security credentials as the driver
   that launched it. To override, provide a mapping of specifying the locations
   of ``cert_file`` and ``key_file``. See the :class:`Security` docstring for
   more information.

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -193,10 +193,10 @@ message ApplicationReport {
 }
 
 
-// Daemon only definitions
+// Driver only definitions
 
 
-service Daemon {
+service Driver {
   rpc ping (Empty) returns (Empty);
 
   rpc getStatus (Application) returns (ApplicationReport);

--- a/java/src/main/resources/log4j.properties
+++ b/java/src/main/resources/log4j.properties
@@ -1,7 +1,7 @@
 log4j.rootLogger=INFO, console
 
 skein.log.level=INFO
-log4j.logger.com.anaconda.skein.Daemon=${skein.log.level}
+log4j.logger.com.anaconda.skein.Driver=${skein.log.level}
 log4j.logger.com.anaconda.skein.ApplicationMaster=${skein.log.level}
 log4j.logger.com.anaconda.skein.WebUI=${skein.log.level}
 

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -1,7 +1,7 @@
 from . import kv
 from .core import Client, ApplicationClient, properties
-from .exceptions import (SkeinError, ConnectionError, DaemonNotRunningError,
-                         ApplicationNotRunningError, DaemonError,
+from .exceptions import (SkeinError, ConnectionError, DriverNotRunningError,
+                         ApplicationNotRunningError, DriverError,
                          ApplicationError)
 from .model import (Security, ApplicationSpec, Service, File, Resources,
                     FileType, FileVisibility, ACLs, Master)

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -6,6 +6,9 @@ from .exceptions import (SkeinError, ConnectionError, DriverNotRunningError,
 from .model import (Security, ApplicationSpec, Service, File, Resources,
                     FileType, FileVisibility, ACLs, Master)
 
+# TODO: deprecated, remove after next release cycle
+from .exceptions import DaemonError, DaemonNotRunningError
+
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/skein/core.py
+++ b/skein/core.py
@@ -15,7 +15,7 @@ from . import proto
 from .compatibility import PY2, makedirs, isidentifier, Mapping
 from .exceptions import (context, FileNotFoundError, ConnectionError,
                          TimeoutError, ApplicationNotRunningError,
-                         ApplicationError, DaemonNotRunningError, DaemonError)
+                         ApplicationError, DriverNotRunningError, DriverError)
 from .kv import KeyValueStore
 from .ui import WebUI
 from .model import (Security, ApplicationSpec, ApplicationReport,
@@ -119,9 +119,9 @@ def secure_channel(address, security):
     return grpc.secure_channel(address, creds, options)
 
 
-def _read_daemon():
+def _read_driver():
     try:
-        with open(os.path.join(properties.config_dir, 'daemon'), 'r') as fil:
+        with open(os.path.join(properties.config_dir, 'driver'), 'r') as fil:
             data = json.load(fil)
             address = data['address']
             pid = data['pid']
@@ -130,15 +130,15 @@ def _read_daemon():
     return address, pid
 
 
-def _write_daemon(address, pid):
+def _write_driver(address, pid):
     # Ensure the config dir exists
     makedirs(properties.config_dir, exist_ok=True)
-    # Write to the daemon file
-    with open(os.path.join(properties.config_dir, 'daemon'), 'w') as fil:
+    # Write to the driver file
+    with open(os.path.join(properties.config_dir, 'driver'), 'w') as fil:
         json.dump({'address': address, 'pid': pid}, fil)
 
 
-def _start_daemon(security=None, set_global=False, keytab=None, principal=None,
+def _start_driver(security=None, set_global=False, keytab=None, principal=None,
                   log=None, log_level=None):
     if security is None:
         security = Security.from_default()
@@ -162,7 +162,7 @@ def _start_daemon(security=None, set_global=False, keytab=None, principal=None,
     elif principal is not None:
         raise context.ValueError("Keytab must be specified for keytab login")
 
-    # Compose the command to start the daemon server
+    # Compose the command to start the driver server
     java_bin = ('%s/bin/java' % os.environ['JAVA_HOME']
                 if 'JAVA_HOME' in os.environ
                 else 'java')
@@ -176,7 +176,7 @@ def _start_daemon(security=None, set_global=False, keytab=None, principal=None,
         if os.path.exists(native_path):
             command.append('-Djava.library.path=%s' % native_path)
 
-    command.extend(['com.anaconda.skein.Daemon', '--jar', _SKEIN_JAR])
+    command.extend(['com.anaconda.skein.Driver', '--jar', _SKEIN_JAR])
 
     if keytab is not None:
         command.extend(['--keytab', keytab, '--principal', principal])
@@ -231,17 +231,17 @@ def _start_daemon(security=None, set_global=False, keytab=None, principal=None,
                     stream = connection.makefile(mode="rb")
                     msg = stream.read(4)
                     if not msg:
-                        raise DaemonError("Failed to read in client port")
+                        raise DriverError("Failed to read in client port")
                     port = struct.unpack("!i", msg)[0]
                     break
         else:
-            raise DaemonError("Failed to start java process")
+            raise DriverError("Failed to start java process")
 
     address = 'localhost:%d' % port
 
     if set_global:
-        Client.stop_global_daemon()
-        _write_daemon(address, proc.pid)
+        Client.stop_global_driver()
+        _write_driver(address, proc.pid)
         proc = None
 
     return address, proc
@@ -277,24 +277,24 @@ class Client(_ClientBase):
     Parameters
     ----------
     address : str, optional
-        The address for the daemon. By default will create a new daemon
-        process.  Pass in address explicitly to connect to a different daemon.
-        To connect to the global daemon see ``Client.from_global_daemon``.
+        The address for the driver. By default will create a new driver
+        process.  Pass in address explicitly to connect to a different driver.
+        To connect to the global driver see ``Client.from_global_driver``.
     security : Security, optional
-        The security configuration to use to communicate with the daemon.
+        The security configuration to use to communicate with the driver.
         Defaults to the global configuration.
     keytab : str, optional
-        Path to a keytab file to use when starting the daemon. If not provided,
-        the daemon will login using the ticket cache instead.
+        Path to a keytab file to use when starting the driver. If not provided,
+        the driver will login using the ticket cache instead.
     principal : str, optional
-        The principal to use when starting the daemon with a keytab.
+        The principal to use when starting the driver with a keytab.
     log : str, bool, or None, optional
-        When starting a new daemon, sets the logging behavior for the daemon.
+        When starting a new driver, sets the logging behavior for the driver.
         Values may be a path for logs to be written to, ``None`` to log to
         stdout/stderr, or ``False`` to turn off logging completely. Default is
         ``None``.
     log_level : str or skein.model.LogLevel, optional
-        The daemon log level. Sets the ``skein.log.level`` system property. One
+        The driver log level. Sets the ``skein.log.level`` system property. One
         of {'ALL', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL', 'OFF'}
         (from most to least verbose). Default is 'INFO'.
 
@@ -304,8 +304,8 @@ class Client(_ClientBase):
     ...     app_id = client.submit('spec.yaml')
     """
     __slots__ = ('address', 'security', '_stub', '_proc')
-    _server_name = 'daemon'
-    _server_error = DaemonError
+    _server_name = 'driver'
+    _server_error = DriverError
 
     def __init__(self, address=None, security=None, keytab=None,
                  principal=None, log=None, log_level=None):
@@ -313,7 +313,7 @@ class Client(_ClientBase):
             security = Security.from_default()
 
         if address is None:
-            address, proc = _start_daemon(security=security,
+            address, proc = _start_driver(security=security,
                                           keytab=keytab,
                                           principal=principal,
                                           log=log,
@@ -322,7 +322,7 @@ class Client(_ClientBase):
             proc = None
 
         with grpc_fork_support_disabled():
-            self._stub = proto.DaemonStub(secure_channel(address, security))
+            self._stub = proto.DriverStub(secure_channel(address, security))
         self.address = address
         self.security = security
         self._proc = proc
@@ -332,55 +332,55 @@ class Client(_ClientBase):
             self._call('ping', proto.Empty())
         except Exception:
             if proc is not None:
-                proc.stdin.close()  # kill the daemon on error
+                proc.stdin.close()  # kill the driver on error
                 proc.wait()
             raise
 
     @classmethod
-    def from_global_daemon(self):
-        """Connect to the global daemon."""
-        address, _ = _read_daemon()
+    def from_global_driver(self):
+        """Connect to the global driver."""
+        address, _ = _read_driver()
 
         if address is None:
-            raise DaemonNotRunningError("No daemon currently running")
+            raise DriverNotRunningError("No driver currently running")
 
         security = Security.from_default()
         return Client(address=address, security=security)
 
     @staticmethod
-    def start_global_daemon(keytab=None, principal=None, log=None, log_level=None):
-        """Start the global daemon.
+    def start_global_driver(keytab=None, principal=None, log=None, log_level=None):
+        """Start the global driver.
 
-        No-op if the global daemon is already running.
+        No-op if the global driver is already running.
 
         Parameters
         ----------
         keytab : str, optional
-            Path to a keytab file to use when starting the daemon. If not
-            provided, the daemon will login using the ticket cache instead.
+            Path to a keytab file to use when starting the driver. If not
+            provided, the driver will login using the ticket cache instead.
         principal : str, optional
-            The principal to use when starting the daemon with a keytab.
+            The principal to use when starting the driver with a keytab.
         log : str, bool, or None, optional
-            Sets the logging behavior for the daemon. Values may be a path for
+            Sets the logging behavior for the driver. Values may be a path for
             logs to be written to, ``None`` to log to stdout/stderr, or
             ``False`` to turn off logging completely. Default is ``None``.
         log_level : str or skein.model.LogLevel, optional
-            The daemon log level. Sets the ``skein.log.level`` system property.
+            The driver log level. Sets the ``skein.log.level`` system property.
             One of {'ALL', 'TRACE', 'DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL',
             'OFF'} (from most to least verbose). Default is 'INFO'.
 
         Returns
         -------
         address : str
-            The address of the daemon
+            The address of the driver
         """
         try:
-            client = Client.from_global_daemon()
-        except DaemonNotRunningError:
+            client = Client.from_global_driver()
+        except DriverNotRunningError:
             pass
         else:
             return client.address
-        address, _ = _start_daemon(set_global=True,
+        address, _ = _start_driver(set_global=True,
                                    keytab=keytab,
                                    principal=principal,
                                    log=log,
@@ -388,23 +388,23 @@ class Client(_ClientBase):
         return address
 
     @staticmethod
-    def stop_global_daemon():
-        """Stops the global daemon if running.
+    def stop_global_driver():
+        """Stops the global driver if running.
 
-        No-op if no global daemon is running."""
-        address, pid = _read_daemon()
+        No-op if no global driver is running."""
+        address, pid = _read_driver()
         if address is None:
             return
 
         try:
             Client(address=address)
-        except DaemonNotRunningError:
+        except DriverNotRunningError:
             pass
         else:
             os.kill(pid, signal.SIGTERM)
 
         try:
-            os.remove(os.path.join(properties.config_dir, 'daemon'))
+            os.remove(os.path.join(properties.config_dir, 'driver'))
         except OSError:
             pass
 
@@ -412,7 +412,7 @@ class Client(_ClientBase):
         return 'Client<%s>' % self.address
 
     def close(self):
-        """Closes the java daemon if started by this client. No-op otherwise."""
+        """Closes the java driver if started by this client. No-op otherwise."""
         if self._proc is not None:
             self._proc.stdin.close()
             self._proc.wait()

--- a/skein/core.py
+++ b/skein/core.py
@@ -7,6 +7,7 @@ import signal
 import socket
 import struct
 import subprocess
+import warnings
 from contextlib import closing
 
 import grpc
@@ -407,6 +408,18 @@ class Client(_ClientBase):
             os.remove(os.path.join(properties.config_dir, 'driver'))
         except OSError:
             pass
+
+    # TODO: deprecated, remove after next release cycle
+    @staticmethod
+    def start_global_daemon():  # pragma: no cover
+        warnings.warn("start_global_daemon is deprecated, use start_global_driver "
+                      "instead")
+        Client.start_global_driver()
+
+    @staticmethod
+    def stop_global_daemon():  # pragma: no cover
+        warnings.warn("stop_global_daemon is deprecated, use stop_global_driver instead")
+        Client.stop_global_driver()
 
     def __repr__(self):
         return 'Client<%s>' % self.address

--- a/skein/exceptions.py
+++ b/skein/exceptions.py
@@ -11,9 +11,9 @@ __all__ = ('FileExistsError',    # py2 compat
            'SkeinError',
            'ConnectionError',
            'TimeoutError',
-           'DaemonNotRunningError',
+           'DriverNotRunningError',
            'ApplicationNotRunningError',
-           'DaemonError',
+           'DriverError',
            'ApplicationError')
 
 
@@ -42,23 +42,23 @@ class SkeinError(Exception):
 
 
 class ConnectionError(SkeinError, _ConnectionError):
-    """Failed to connect to the daemon or application master"""
+    """Failed to connect to the driver or application master"""
 
 
 class TimeoutError(SkeinError, _TimeoutError):
-    """Request to daemon or application master timed out"""
+    """Request to driver or application master timed out"""
 
 
-class DaemonNotRunningError(ConnectionError):
-    """The daemon process is not currently running"""
+class DriverNotRunningError(ConnectionError):
+    """The driver process is not currently running"""
 
 
 class ApplicationNotRunningError(ConnectionError):
     """The application master is not currently running"""
 
 
-class DaemonError(SkeinError):
-    """Internal exceptions from the daemon"""
+class DriverError(SkeinError):
+    """Internal exceptions from the driver"""
 
 
 class ApplicationError(SkeinError):

--- a/skein/exceptions.py
+++ b/skein/exceptions.py
@@ -65,6 +65,37 @@ class ApplicationError(SkeinError):
     """Internal exceptions from the application master"""
 
 
+# TODO: DaemonError/DaemonNotRunningError are deprecated, remove after next
+# release cycle
+def _add_ABCMeta(cls):
+    """Use the metaclass ABCMeta for this class"""
+    from abc import ABCMeta
+    return ABCMeta(cls.__name__, cls.__bases__, cls.__dict__.copy())
+
+
+@_add_ABCMeta
+class DaemonError(DriverError):
+    """Deprecated, use DriverError instead"""
+    @classmethod
+    def __subclasshook__(cls, other):
+        warnings.warn("DaemonError is deprecated, use DriverError instead")
+        if other is DriverError:
+            return True
+        return NotImplemented
+
+
+@_add_ABCMeta
+class DaemonNotRunningError(DriverNotRunningError):
+    """Deprecated, use DriverNotRunningError instead"""
+    @classmethod
+    def __subclasshook__(cls, other):
+        warnings.warn("DaemonNotRunningError is deprecated, use "
+                      "DriverNotRunningError instead")
+        if other is DriverNotRunningError:
+            return True
+        return NotImplemented
+
+
 class _Context(object):
     def __init__(self):
         self.is_cli = False

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -15,4 +15,4 @@ from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         WatchResponse)
 from .skein_pb2 import (Proxy, RemoveProxyRequest, UIInfoRequest, UIInfoResponse,
                         GetProxiesRequest, GetProxiesResponse)
-from .skein_pb2_grpc import DaemonStub, AppMasterStub
+from .skein_pb2_grpc import DriverStub, AppMasterStub

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -141,7 +141,7 @@ def test_client(security, kinit, tmpdir):
     with pytest.raises(skein.ConnectionError):
         client2.get_applications()
 
-    # Connection error on connecting to missing daemon
+    # Connection error on connecting to missing driver
     with pytest.raises(skein.ConnectionError):
         skein.Client(address=client.address, security=security)
 
@@ -176,7 +176,7 @@ def test_client_errors_nicely_if_not_logged_in(security, not_logged_in):
                            ('connect', (appid,)),
                            ('kill_application', (appid,)),
                            ('submit', (spec,))]:
-            with pytest.raises(skein.DaemonError) as exc:
+            with pytest.raises(skein.DriverError) as exc:
                 getattr(client, func)(*args)
             assert 'kinit' in str(exc.value)
 
@@ -215,7 +215,7 @@ def test_client_login_from_keytab(security, not_logged_in):
         client.get_applications()
 
     # Improper principal/keytab pair
-    with pytest.raises(skein.DaemonError):
+    with pytest.raises(skein.DriverError):
         skein.Client(principal='not_the_right_user', keytab=KEYTAB_PATH,
                      security=security)
 
@@ -606,7 +606,7 @@ def test_proxy_user_no_permissions(client):
         }
     )
     # No permission to submit as user
-    with pytest.raises(skein.DaemonError) as exc:
+    with pytest.raises(skein.DriverError) as exc:
         client.submit(spec)
 
     exc_msg = str(exc.value)

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -647,3 +647,16 @@ def test_security_specified(client):
     assert remote_security.key_bytes is None
     assert remote_security.cert_file.source.startswith('hdfs')
     assert remote_security.key_file.source.startswith('hdfs')
+
+
+def test_daemon_errors_deprecated():
+    with pytest.warns(UserWarning):
+        assert isinstance(skein.DriverError(), skein.DaemonError)
+    with pytest.warns(UserWarning):
+        assert not isinstance(skein.SkeinError(), skein.DaemonError)
+
+    with pytest.warns(UserWarning):
+        assert isinstance(skein.DriverNotRunningError(),
+                          skein.DaemonNotRunningError)
+    with pytest.warns(UserWarning):
+        assert not isinstance(skein.SkeinError(), skein.DaemonNotRunningError)


### PR DESCRIPTION
Rename "Daemon" to "Driver"

The "Daemon" process name has been confusing for some users, here we rename it to "Driver" to better reflect its purpose and usage. We smoothly deprecate the following names:

- `DaemonError` -> `DriverError`
- `DaemonNotRunningError` -> `DriverNotRunningError`
- `Client.start_global_daemon` -> `Client.start_global_driver`
- `Client.stop_global_daemon` -> `Client.stop_global_driver`
- `skein daemon ...` -> `skein driver ...`

The documentation has also been updated to reflect this change.