### PR TITLE
Driver works in YARN container

### DIFF
--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -538,7 +538,7 @@ public class ApplicationMaster {
   public static void main(String[] args) {
     // Specify the netty native workdir. This is necessary for systems where
     // `/tmp` is not executable.
-    System.setProperty("io.netty.native.workdir", "./");
+    Utils.configureNettyNativeWorkDir();
 
     ApplicationMaster appMaster = new ApplicationMaster();
 

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -159,7 +159,10 @@ public class Driver {
 
   /** Main Entry Point. **/
   public static void main(String[] args) {
-    boolean result = false;
+    // Maybe specify the netty native workdir. This is necessary for systems
+    // where `/tmp` is not executable.
+    Utils.configureNettyNativeWorkDir();
+
     try {
       Driver driver = new Driver();
       driver.init(args);

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -483,7 +483,7 @@ public class Driver {
 
     // Setup the LocalResources for the application master
     Map<String, LocalResource> lr = new HashMap<String, LocalResource>();
-    lr.put("skein.jar", newLocalResource(uploadCache, appDir, jarPath));
+    lr.put(".skein.jar", newLocalResource(uploadCache, appDir, jarPath));
     if (spec.getMaster().hasLogConfig()) {
       LocalResource logConfig = spec.getMaster().getLogConfig();
       finalizeLocalResource(uploadCache, appDir, logConfig, false);

--- a/java/src/main/java/com/anaconda/skein/Utils.java
+++ b/java/src/main/java/com/anaconda/skein/Utils.java
@@ -86,6 +86,20 @@ public class Utils {
         new CustomThreadFactory(name, isDaemon));
   }
 
+  public static void configureNettyNativeWorkDir() {
+    final String property = "io.netty.native.workdir";
+
+    // Already set by user, do nothing
+    if (System.getProperty(property) != null) {
+      return;
+    }
+
+    // Set to current directory if we're in a container
+    if (System.getenv("CONTAINER_ID") != null) {
+      System.setProperty(property, "./");
+    }
+  }
+
   public static String formatAcl(List<String> users, List<String> groups) {
     // "*" in either groups or users -> "*"
     if (users.contains("*") || groups.contains("*")) {

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -252,7 +252,7 @@ def test_client_login_from_keytab(security, not_logged_in):
         skein.Client(keytab=KEYTAB_PATH, security=security)
 
 
-def test_application_client_from_current(monkeypatch, tmpdir, security):
+def test_appclient_and_security_in_container(monkeypatch, tmpdir, security):
     # Not running in a container
     with pytest.raises(ValueError) as exc:
         skein.ApplicationClient.from_current()
@@ -277,6 +277,10 @@ def test_application_client_from_current(monkeypatch, tmpdir, security):
         skein.ApplicationClient.from_current()
     assert str(exc.value) == "Failed to resolve .skein.{crt,pem} in 'LOCAL_DIRS'"
 
+    with pytest.raises(FileNotFoundError) as exc:
+        skein.Security.from_default()
+    assert str(exc.value) == "Failed to resolve .skein.{crt,pem} in 'LOCAL_DIRS'"
+
     # Add proper LOCAL_DIRS environment
     good_dir = tmpdir.mkdir('good_dir')
     local_dir = good_dir.mkdir(container_id)
@@ -290,6 +294,10 @@ def test_application_client_from_current(monkeypatch, tmpdir, security):
     app = skein.ApplicationClient.from_current()
     assert app.id == app_id
     assert app.address == address
+
+    security2 = skein.Security.from_default()
+    assert security._get_bytes('key') == security2._get_bytes('key')
+    assert security._get_bytes('cert') == security2._get_bytes('cert')
 
 
 def test_simple_app(client):


### PR DESCRIPTION
Two fixes to make the Skein driver/client work properly inside a YARN container:
- Properly set `io.netty.native.workdir` for the driver as well as the application master
- Load the current application's security configuration by default when run inside a container

This allows applications to be submitted from inside a YARN container just as easily as from the edge node.