### PR TITLE
Optionally run application on master node

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -128,6 +128,10 @@ Application Specification
     :members:
     :inherited-members:
 
+.. autoclass:: Master
+    :members:
+    :inherited-members:
+
 .. autoclass:: Service
     :members:
     :inherited-members:
@@ -149,10 +153,6 @@ Application Specification
     :inherited-members:
 
 .. autoclass:: ACLs
-    :members:
-    :inherited-members:
-
-.. autoclass:: Master
     :members:
     :inherited-members:
 

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -64,24 +64,13 @@ Here we create a simple "Hello World" application as a YAML file:
     name: hello_world
     queue: default
 
-    services:
-      my_service:
-        resources:
-          vcores: 1
-          memory: 128 MiB
-        files:
-          payload.txt: payload.txt
-        commands:
-          - echo "Sleeping for 60 seconds"
-          - sleep 60
-          - cat payload.txt
-          - echo "Stopping service"
-
-Where the contents of ``payload.txt`` is:
-
-.. code-block:: text
-
-    Hello World!
+    master:
+      resources:
+        vcores: 1
+        memory: 512 MiB
+      commands:
+        - sleep 60
+        - echo "Hello World!"
 
 Walking through this specification:
 
@@ -93,38 +82,27 @@ Walking through this specification:
      name: hello_world
      queue: default
 
-- The application starts a single service ``my_service`` on a container using 1
-  virtual core and 128 MiB of memory.
-
-  .. code-block:: yaml
-
-     services:
-       my_service:
-         resources:
-           vcores: 1
-           memory: 128 MiB
-
-
-- The file ``payload.txt`` is distributed with the application, and is named
-  ``payload.txt`` both locally and on the running container.
+- The application requests a single container for the *Application Master* with
+  1 virtual core and 512 MiB of memory.
 
   .. code-block:: yaml
 
      ...
-         files:
-           payload.txt: payload.txt
+     master:
+      resources:
+        vcores: 1
+        memory: 512 MiB
 
-- The service runs a few Shell commands. These will be run in order, stopping
-  on the first failure, and all outputs logged in the container logs.
+- The Application Master then runs a few Shell commands. These will be run in
+  order, stopping on the first failure, and all outputs logged in the container
+  logs.
 
   .. code-block:: yaml
 
      ...
-         commands:
-           - echo "Sleeping for 60 seconds"
-           - sleep 60
-           - cat payload.txt
-           - echo "Stopping service"
+      commands:
+        - sleep 60
+        - echo "Hello World!"
 
 
 Submit the Application
@@ -157,7 +135,7 @@ applications that are either ``SUBMITTED``, ``ACCEPTED``, or ``RUNNING``.
 
     $ skein application ls
     APPLICATION_ID                    NAME           STATE      STATUS       CONTAINERS    VCORES    MEMORY
-    application_1526497750451_0009    hello_world    RUNNING    UNDEFINED    2             2         640
+    application_1526497750451_0009    hello_world    RUNNING    UNDEFINED    1             1         512
 
 You can also filter by application state. Here we show all ``KILLED`` and ``FAILED`` applications:
 
@@ -176,15 +154,16 @@ To get the status of a specific application, use the `skein application status
 
     $ skein application status application_1526497750451_0009
     APPLICATION_ID                    NAME           STATE      STATUS       CONTAINERS    VCORES    MEMORY
-    application_1526497750451_0009    hello_world    RUNNING    UNDEFINED    2             2         640
+    application_1526497750451_0009    hello_world    RUNNING    UNDEFINED    1             1         512
 
 
 Kill a running application
 --------------------------
 
-By default, applications shutdown once all of their services have exited *or*
-any service exits with a non-zero exit code. To explicitly kill an application,
-use the `skein application kill <cli.html#skein-application-kill>`__ command:
+By default, applications shutdown once all of their containers have exited *or*
+any containers exits with a non-zero exit code. To explicitly kill an
+application, use the `skein application kill
+<cli.html#skein-application-kill>`__ command:
 
 .. code::
 

--- a/java/src/main/java/com/anaconda/skein/Utils.java
+++ b/java/src/main/java/com/anaconda/skein/Utils.java
@@ -13,10 +13,12 @@ import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 
 import java.io.IOException;
+import java.io.OutputStream;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Set;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -131,6 +133,21 @@ public class Utils {
     long timestamp = Long.valueOf(parts[1]);
     int id = Integer.valueOf(parts[2]);
     return ApplicationId.newInstance(timestamp, id);
+  }
+
+  public static void writeScript(List<String> commands, OutputStream out)
+      throws IOException {
+    final StringBuilder script = new StringBuilder();
+    script.append("set -e -x");
+    for (String c : commands) {
+      script.append("\n");
+      script.append(c);
+    }
+    try {
+      out.write(script.toString().getBytes(StandardCharsets.UTF_8));
+    } finally {
+      out.close();
+    }
   }
 
   public static LocalResource localResource(FileSystem fs, Path path,

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -124,9 +124,16 @@ message Security {
 
 
 message Master {
+  // Application-master configuration
   File log_config = 1;
   Log.Level log_level = 2;
   Security security = 3;
+
+  // Master service configuration parameters
+  Resources resources = 4;
+  map<string, File> files = 5;
+  map<string, string> env = 6;
+  repeated string commands = 7;
 }
 
 

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -120,9 +120,13 @@ def ensure_shutdown(client, app_id, status=None):
 
 
 @contextmanager
-def run_application(client, spec=sleep_until_killed):
-    app = client.submit_and_connect(spec)
-    with ensure_shutdown(client, app.id):
+def run_application(client, spec=sleep_until_killed, connect=True):
+    if connect:
+        app = client.submit_and_connect(spec)
+        app_id = app.id
+    else:
+        app_id = app = client.submit(spec)
+    with ensure_shutdown(client, app_id):
         yield app
 
 


### PR DESCRIPTION
Allows running a single user process on the application master. This allows singleton services to start up *much* faster.

The master process also manages the lifetime of the application - when the process exits the application shuts down automatically, regardless of the state of other services. The application final status is determined by the exit code of the process (0 for succeeded, anything else for failed).

This can be useful for running things like the dask client for [dask-yarn submit](http://yarn.dask.org/en/latest/submit.html) (more robustly ensure the cluster shutsdown after submission) or starting single processes like a jupyter notebook server (used in [yarnspawner](https://github.com/jcrist/yarnspawner) to launch jupyterhub on YARN).

Fixes #118.