### PR TITLE
Deprecate ``commands`` for ``script``

### DIFF
--- a/docs/source/debugging.rst
+++ b/docs/source/debugging.rst
@@ -35,31 +35,6 @@ application master. This is a good first place to look when encountering an
 unexpected failure or bug.
 
 
-Useful Things to Log
---------------------
-
-Since you often don't have access to the worker nodes, it can be useful to log
-the full container environment before executing any application specific
-commands. This includes all localized paths, and all environment variables.
-Since ``skein`` accepts multiple commands for each service, this is easy to do.
-
-.. code-block:: none
-
-    services:
-      my_service:
-        commands:
-          # List all local files, including file types
-          - ls -l
-          # List all environment variables and their values
-          - env
-          # Application specific commands...
-
-
-It's also useful to log application logic as your application progresses. This
-could as simple as periodic ``print`` statements, or using the standard
-library's `logging module <https://docs.python.org/3/library/logging.html>`_.
-
-
 Configuring Logging in the Application Master
 ---------------------------------------------
 
@@ -118,12 +93,3 @@ are also a few ways to do this:
     # Create a client, logging to `driver.log` with "debug" log level
     import skein
     client = skein.Client(log_level='debug', log='driver.log')
-
-
-Start a Remote IPython Kernel on the Container
-----------------------------------------------
-
-As a last resort, it can be useful to Skein's remote `IPython
-<https://ipython.org/>`_ kernel recipe to start an IPython kernel on the
-failing container, and connect to the kernel to debug locally. Refer to the
-:doc:`recipe documentation <recipes-ipython-kernel>` for more information.

--- a/docs/source/distributing-files.rst
+++ b/docs/source/distributing-files.rst
@@ -198,8 +198,8 @@ Using the Packaged Environment
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To use the packaged environment in a service specification, you need to include
-the archive in ``files``, and activate the environment in the ``commands``
-list. This looks the same for environments packaged using either tool.
+the archive in ``files``, and activate the environment in the ``script``. This
+looks the same for environments packaged using either tool.
 
 .. code-block:: yaml
 
@@ -210,13 +210,13 @@ list. This looks the same for environments packaged using either tool.
           # into a directory named ``environment`` in each container.
           environment: environment.tar.gz
 
-        commands:
+        script: |
           # Activate the environment
-          - source environment/bin/activate
+          source environment/bin/activate
 
           # Run commands inside the environment. All executables or imported
           # python libraries will be from within the packaged environment.
-          - my-cool-application
+          my-cool-application
 
 
 .. _conda-pack: https://conda.github.io/conda-pack/

--- a/docs/source/key-value-store.rst
+++ b/docs/source/key-value-store.rst
@@ -51,8 +51,8 @@ forever.
     ...     resources:
     ...       memory: 128 MiB
     ...       vcores: 1
-    ...     commands:
-    ...       - sleep infinity
+    ...     script: |
+    ...       sleep infinity
     ... """)
     >>> client = skein.Client()
     >>> app = client.submit_and_connect(spec)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -68,9 +68,9 @@ Here we create a simple "Hello World" application as a YAML file:
       resources:
         vcores: 1
         memory: 512 MiB
-      commands:
-        - sleep 60
-        - echo "Hello World!"
+      script: |
+        sleep 60
+        echo "Hello World!"
 
 Walking through this specification:
 
@@ -89,20 +89,19 @@ Walking through this specification:
 
      ...
      master:
-      resources:
-        vcores: 1
-        memory: 512 MiB
+       resources:
+         vcores: 1
+         memory: 512 MiB
 
-- The Application Master then runs a few Shell commands. These will be run in
-  order, stopping on the first failure, and all outputs logged in the container
-  logs.
+- The Application Master then runs a bash script. Both ``stdout`` and
+  ``stderr`` of this script will be written to the container logs.
 
   .. code-block:: yaml
 
      ...
-      commands:
-        - sleep 60
-        - echo "Hello World!"
+       script: |
+         sleep 60
+         echo "Hello World!"
 
 
 Submit the Application

--- a/docs/source/recipes-ipython-kernel.rst
+++ b/docs/source/recipes-ipython-kernel.rst
@@ -99,11 +99,11 @@ the `specification docs <specification.html>`__.
           # This will be automatically extracted by YARN to the directory
           # ``environment`` during resource localization.
           environment: environment.tar.gz
-        commands:
+        script: |
           # Activate our environment
-          - source environment/bin/activate
+          source environment/bin/activate
           # Start the remote ipython kernel
-          - python -m skein.recipes.ipython_kernel
+          python -m skein.recipes.ipython_kernel
 
 
 Start the Remote IPython Kernel

--- a/docs/source/recipes-jupyter-notebook.rst
+++ b/docs/source/recipes-jupyter-notebook.rst
@@ -147,11 +147,11 @@ the `specification docs <specification.html>`__.
           # This will be automatically extracted by YARN to the directory
           # ``environment`` during resource localization.
           environment: environment.tar.gz
-        commands:
+        script: |
           # Activate our environment
-          - source environment/bin/activate
+          source environment/bin/activate
           # Start the jupyter notebook server
-          - python -m skein.recipes.jupyter_notebook
+          python -m skein.recipes.jupyter_notebook
 
 
 Start the Jupyter Notebook Server

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -51,6 +51,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
@@ -246,15 +247,15 @@ public class ApplicationMaster {
 
   private void startApplicationDriver() throws IOException {
     Model.Master master = spec.getMaster();
-    if (master.getCommands().isEmpty()) {
+    if (master.getScript().isEmpty()) {
       // Nothing to do
       return;
     }
     LOG.debug("Writing driver script...");
-    Utils.writeScript(master.getCommands(), new FileOutputStream(".skein.script.sh"));
+    Utils.stringToFile(master.getScript(), new FileOutputStream(".skein.sh"));
     String logdir = System.getProperty("skein.log.directory");
     ProcessBuilder pb = new ProcessBuilder()
-        .command("bash", ".skein.script.sh")
+        .command("bash", ".skein.sh")
         .redirectErrorStream(true)
         .redirectOutput(new File(logdir, "application.driver.log"));
     updateServiceEnvironment(pb.environment(), master.getResources(), null);
@@ -1043,7 +1044,7 @@ public class ApplicationMaster {
             ContainerLaunchContext.newInstance(
                 service.getLocalResources(),
                 env,
-                service.getCommands(),
+                Arrays.asList(service.getScript()),
                 null,
                 tokens,
                 spec.getAcls().getYarnAcls());

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -525,15 +525,13 @@ public class Driver {
     // Write the service script to file
     final Path scriptPath = new Path(appDir, serviceName + ".sh");
     LOG.debug("Writing script for service '{}' to {}", serviceName, scriptPath);
-    Utils.writeScript(service.getCommands(), fs.create(scriptPath));
+    Utils.stringToFile(service.getScript(), fs.create(scriptPath));
     LocalResource scriptFile = Utils.localResource(fs, scriptPath,
                                                    LocalResourceType.FILE);
 
-    // Build command to execute script and set as new commands
-    ArrayList<String> commands = new ArrayList<String>();
+    // Build command to execute script and set as new script
     String logdir = ApplicationConstants.LOG_DIR_EXPANSION_VAR;
-    commands.add("bash .script.sh >" + logdir + "/" + serviceName + ".log 2>&1");
-    service.setCommands(commands);
+    service.setScript("bash .skein.sh >" + logdir + "/" + serviceName + ".log 2>&1");
 
     // Upload files/archives as necessary
     Map<String, LocalResource> lr = service.getLocalResources();
@@ -542,7 +540,7 @@ public class Driver {
     }
 
     // Add script/crt/pem files
-    lr.put(".script.sh", scriptFile);
+    lr.put(".skein.sh", scriptFile);
     lr.put(".skein.crt", certFile);
     lr.put(".skein.pem", keyFile);
 

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -44,7 +44,7 @@ public class Model {
     private Resource resources;
     private Map<String, LocalResource> localResources;
     private Map<String, String> env;
-    private List<String> commands;
+    private String script;
     private Set<String> depends;
 
     public Service() {}
@@ -58,7 +58,7 @@ public class Model {
                    Resource resources,
                    Map<String, LocalResource> localResources,
                    Map<String, String> env,
-                   List<String> commands,
+                   String script,
                    Set<String> depends) {
       this.instances = instances;
       this.nodeLabel = nodeLabel;
@@ -69,7 +69,7 @@ public class Model {
       this.resources = resources;
       this.localResources = localResources;
       this.env = env;
-      this.commands = commands;
+      this.script = script;
       this.depends = depends;
     }
 
@@ -81,7 +81,7 @@ public class Model {
               + "resources: " + resources + "\n"
               + "localResources: " + localResources + "\n"
               + "env: " + env + "\n"
-              + "commands: " + commands + "\n"
+              + "script: " + script + "\n"
               + "depends: " + depends);
     }
 
@@ -112,8 +112,8 @@ public class Model {
     public void setEnv(Map<String, String> env) { this.env = env; }
     public Map<String, String> getEnv() { return env; }
 
-    public void setCommands(List<String> commands) { this.commands = commands; }
-    public List<String> getCommands() { return commands; }
+    public void setScript(String script) { this.script = script; }
+    public String getScript() { return script; }
 
     public void setDepends(Set<String> depends) { this.depends = depends; }
     public Set<String> getDepends() { return depends; }
@@ -126,9 +126,9 @@ public class Model {
       throwIfLessThan(resources.getVirtualCores(), 1, "resources.vcores");
       throwIfNull(localResources, "localResources");
       throwIfNull(env, "env");
-      throwIfNull(commands, "commands");
-      if (commands.size() == 0) {
-        throw new IllegalArgumentException("There must be at least one command");
+      throwIfNull(script, "script");
+      if (script.isEmpty()) {
+        throw new IllegalArgumentException("Script must be provided.");
       }
       throwIfNull(depends, "depends");
       throwIfNull(nodes, "nodes");
@@ -240,7 +240,7 @@ public class Model {
     private Resource resources;
     private Map<String, LocalResource> localResources;
     private Map<String, String> env;
-    private List<String> commands;
+    private String script;
 
     private LocalResource logConfig;
     private Level logLevel;
@@ -258,8 +258,8 @@ public class Model {
     public void setEnv(Map<String, String> env) { this.env = env; }
     public Map<String, String> getEnv() { return env; }
 
-    public void setCommands(List<String> commands) { this.commands = commands; }
-    public List<String> getCommands() { return commands; }
+    public void setScript(String script) { this.script = script; }
+    public String getScript() { return script; }
 
     public void setLogConfig(LocalResource logConfig) { this.logConfig = logConfig; }
     public LocalResource getLogConfig() { return this.logConfig; }
@@ -278,7 +278,7 @@ public class Model {
       throwIfLessThan(resources.getVirtualCores(), 1, "resources.vcores");
       throwIfNull(localResources, "localResources");
       throwIfNull(env, "env");
-      throwIfNull(commands, "commands");
+      throwIfNull(script, "script");
       throwIfNull(logLevel, "logLevel");
       if (security != null) {
         security.validate();
@@ -368,9 +368,9 @@ public class Model {
       throwIfNull(master, "master");
       master.validate();
       throwIfNull(services, "services");
-      if (services.size() == 0 && master.getCommands().size() == 0) {
+      if (services.size() == 0 && master.getScript().length() == 0) {
         throw new IllegalArgumentException(
-            "There must be either at least one service or additional commands "
+            "There must be either at least one service or a script "
             + "to run on the application master");
       }
       for (Service s: services.values()) {

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -279,7 +279,7 @@ public class MsgUtils {
         .setMaxRestarts(service.getMaxRestarts())
         .setResources(writeResources(service.getResources()))
         .putAllEnv(service.getEnv())
-        .addAllCommands(service.getCommands())
+        .setScript(service.getScript())
         .addAllDepends(service.getDepends());
 
     for (Map.Entry<String, LocalResource> entry : service.getLocalResources().entrySet()) {
@@ -303,7 +303,7 @@ public class MsgUtils {
         readResources(service.getResources()),
         localResources,
         new HashMap<String, String>(service.getEnvMap()),
-        new ArrayList<String>(service.getCommandsList()),
+        service.getScript(),
         new HashSet<String>(service.getDependsList()));
   }
 
@@ -422,7 +422,7 @@ public class MsgUtils {
     Msg.Master.Builder builder = Msg.Master.newBuilder()
         .setResources(writeResources(master.getResources()))
         .putAllEnv(master.getEnv())
-        .addAllCommands(master.getCommands())
+        .setScript(master.getScript())
         .setLogLevel(writeLogLevel(master.getLogLevel()));
 
     for (Map.Entry<String, LocalResource> entry : master.getLocalResources().entrySet()) {
@@ -450,7 +450,7 @@ public class MsgUtils {
     out.setLocalResources(localResources);
     out.setResources(readResources(master.getResources()));
     out.setEnv(new HashMap<String, String>(master.getEnvMap()));
-    out.setCommands(new ArrayList<String>(master.getCommandsList()));
+    out.setScript(master.getScript());
 
     if (master.hasLogConfig()) {
       out.setLogConfig(readFile(master.getLogConfig()));

--- a/java/src/main/java/com/anaconda/skein/Utils.java
+++ b/java/src/main/java/com/anaconda/skein/Utils.java
@@ -135,16 +135,10 @@ public class Utils {
     return ApplicationId.newInstance(timestamp, id);
   }
 
-  public static void writeScript(List<String> commands, OutputStream out)
+  public static void stringToFile(String data, OutputStream out)
       throws IOException {
-    final StringBuilder script = new StringBuilder();
-    script.append("set -e -x");
-    for (String c : commands) {
-      script.append("\n");
-      script.append(c);
-    }
     try {
-      out.write(script.toString().getBytes(StandardCharsets.UTF_8));
+      out.write(data.getBytes(StandardCharsets.UTF_8));
     } finally {
       out.close();
     }

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -82,7 +82,7 @@ message Service {
   Resources resources = 7;
   map<string, File> files = 8;
   map<string, string> env = 9;
-  repeated string commands = 10;
+  string script = 10;
   repeated string depends = 11;
 }
 
@@ -133,7 +133,7 @@ message Master {
   Resources resources = 4;
   map<string, File> files = 5;
   map<string, string> env = 6;
-  repeated string commands = 7;
+  string script = 7;
 }
 
 

--- a/skein/recipes/ipython_kernel.py
+++ b/skein/recipes/ipython_kernel.py
@@ -28,8 +28,8 @@ class SkeinIPKernelApp(IPKernelApp):
     >>> from skein import Client, ApplicationSpec, Service, Resources
     >>> ipykernel = Service(resources=Resources(memory=2048, vcores=1),
     ...                     files={'environment': 'environment.tar.gz'},
-    ...                     commands=['source environment/bin/activate',
-    ...                               'python -m skein.recipes.ipython_kernel'])
+    ...                     script=('source environment/bin/activate\n'
+    ...                             'python -m skein.recipes.ipython_kernel'))
     >>> spec = ApplicationSpec(name='ipython-kernel',
     ...                        services={'ipykernel': ipykernel})
 

--- a/skein/recipes/jupyter_notebook.py
+++ b/skein/recipes/jupyter_notebook.py
@@ -28,8 +28,8 @@ class SkeinNotebookApp(NotebookApp):
     >>> from skein import Client, ApplicationSpec, Service, Resources
     >>> notebook = Service(resources=Resources(memory=2048, vcores=1),
     ...                    files={'environment': 'environment.tar.gz'},
-    ...                    commands=['source environment/bin/activate',
-    ...                              'python -m skein.recipes.jupyter_notebook'])
+    ...                    script=('source environment/bin/activate\n'
+    ...                            'python -m skein.recipes.jupyter_notebook'))
     >>> spec = ApplicationSpec(name='jupyter-notebook',
     ...                        services={'notebook': notebook})
 

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -70,7 +70,7 @@ def client(security, kinit):
 
 
 sleeper = skein.Service(resources=skein.Resources(memory=128, vcores=1),
-                        commands=['sleep infinity'])
+                        script='sleep infinity')
 
 
 sleep_until_killed = skein.ApplicationSpec(name="sleep_until_killed",

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -24,8 +24,7 @@ tags:
 
 services:
     sleeper:
-        commands:
-            - sleep infinity
+        script: sleep infinity
 """
 
 

--- a/skein/test/test_ui.py
+++ b/skein/test/test_ui.py
@@ -8,7 +8,7 @@ requests = pytest.importorskip('requests')
 
 
 simplehttp = skein.Service(resources=skein.Resources(memory=128, vcores=1),
-                           commands=['/usr/bin/python -m SimpleHTTPServer 8888'])
+                           script='/usr/bin/python -m SimpleHTTPServer 8888')
 spec = skein.ApplicationSpec(name="test_webui",
                              queue="default",
                              services={'simplehttp': simplehttp})
@@ -231,7 +231,7 @@ def test_webui_acls(client, has_kerberos_enabled, ui_users, checks):
         pytest.skip("Testing only implemented for simple authentication")
 
     service = skein.Service(resources=skein.Resources(memory=128, vcores=1),
-                            commands=['sleep infinity'])
+                            script='sleep infinity')
     spec = skein.ApplicationSpec(name="test_webui_acls",
                                  queue="default",
                                  acls=skein.ACLs(enable=True, ui_users=ui_users),


### PR DESCRIPTION
Deprecate the ``commands`` field in favor of ``script`` instead.

This removes the oddness of us composing a script from a list of
commands, as well as the automatic addition of ``set -x -e``.

Fixes #121.