### PR TITLE
Add ``skein driver stop --force``

### DIFF
--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -10,6 +10,14 @@ import pytest
 import skein
 
 
+def pid_exists(pid):
+    try:
+        os.kill(pid, 0)
+    except OSError:
+        return False
+    return True
+
+
 @contextmanager
 def set_skein_config(tmpdir):
     tmpdir = str(tmpdir)

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -11,7 +11,8 @@ import skein
 from skein.core import Properties
 from skein.exceptions import FileNotFoundError, FileExistsError
 from skein.test.conftest import (run_application, wait_for_containers,
-                                 wait_for_completion, get_logs, KEYTAB_PATH)
+                                 wait_for_completion, get_logs, KEYTAB_PATH,
+                                 pid_exists)
 
 
 def test_properties():
@@ -102,14 +103,6 @@ def test_security_auto_inits(skein_config):
 
     assert not rec
     assert sec == sec2
-
-
-def pid_exists(pid):
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
 
 
 def test_client(security, kinit, tmpdir):


### PR DESCRIPTION
Previously the global driver would only be stopped if skein could verify
that the corresponding PID was actually a skein driver. In the case of
credential mismatch this could result in an inability to stop a running
driver using the skein cli. This adds a `--force` option to always kill
the process, even if we're not sure if it's a driver.

Addresses comment here: https://github.com/jcrist/skein/issues/124#issuecomment-450892520