### PR TITLE
A few fixups for running driver in container

### DIFF
--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -279,6 +279,7 @@ public class ApplicationMaster {
         .redirectErrorStream(true)
         .redirectOutput(new File(logdir, "application.driver.log"));
     updateServiceEnvironment(pb.environment(), amResources, null);
+    pb.environment().remove("CLASSPATH");
 
     // Start the driver process
     LOG.info("Starting application driver");

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -461,6 +461,7 @@ def test_container_environment(runon, client, has_kerberos_enabled):
         assert 'SKEIN_CONTAINER_ID=service_0' in logs
     assert 'SKEIN_RESOURCE_MEMORY=512' in logs
     assert 'SKEIN_RESOURCE_VCORES=1' in logs
+    assert 'CLASSPATH' not in logs
 
     if has_kerberos_enabled:
         assert "LOGIN_ID=[testuser]" in logs


### PR DESCRIPTION
- Don't propogate CLASSPATH to script running on application master
- Don't attempt to acquire an RM delegation token if one has already been acquired.

This allows launching applications from inside a container, as well as using libhdfs (e.g. pyarrow's hdfs) without extra configuration in the driver script.