### PR TITLE
Check if PID exists in global driver

### DIFF
--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -10,14 +10,6 @@ import pytest
 import skein
 
 
-def pid_exists(pid):
-    try:
-        os.kill(pid, 0)
-    except OSError:
-        return False
-    return True
-
-
 @contextmanager
 def set_skein_config(tmpdir):
     tmpdir = str(tmpdir)

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -10,9 +10,9 @@ import pytest
 import skein
 from skein.core import Properties
 from skein.exceptions import FileNotFoundError, FileExistsError
+from skein.utils import pid_exists
 from skein.test.conftest import (run_application, wait_for_containers,
-                                 wait_for_completion, get_logs, KEYTAB_PATH,
-                                 pid_exists)
+                                 wait_for_completion, get_logs, KEYTAB_PATH)
 
 
 def test_properties():

--- a/skein/utils.py
+++ b/skein/utils.py
@@ -1,10 +1,20 @@
 from __future__ import print_function, division, absolute_import
 
+import errno
 import os
 from contextlib import contextmanager
 from datetime import datetime, timedelta
 
 from .compatibility import unicode, UTC
+
+
+def pid_exists(pid):
+    try:
+        os.kill(pid, 0)
+    except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return False
+    return True
 
 
 @contextmanager


### PR DESCRIPTION
Previously we'd fail loudly if the driver file had a pid/address that was no longer correct. Users would have to run:

```
skein driver stop --force
skein driver start
```

in these situations to get a new working global driver. Now we check if the PID doesn't exist, and handle these cases specially:

- `skein driver start` warns that an old driver had died, and starts a new one.
- `skein driver stop` no longer requires `--force` to handle this case (`--force` is still required if the PID exists, but can't be connected with).

Fixes #140