### PR TITLE
Add `allow_failures` field

### DIFF
--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -494,7 +494,7 @@ restart, or 0 to never restart. Optional, default is 0.
 .. code-block:: none
 
     services:
-      my_service:
+      my_service1:
         max_restarts: -1  # always restart
         ...
 
@@ -504,6 +504,29 @@ restart, or 0 to never restart. Optional, default is 0.
 
       my_service3:
         max_restarts: 3   # restart a maximum of 3 times
+        ...
+
+``allow_failures``
+~~~~~~~~~~~~~~~~~~
+
+If False (default), the whole application will shutdown if the number of
+failures for this service exceeds ``max_restarts``. Set to True to keep the
+application running even if the number of failures exceeds this limit.
+Optional, default is False.
+
+**Example**
+
+.. code-block:: none
+
+    services:
+      my_service1:
+        max_restarts: 0         # Never restart
+        allow_failures: True    # Don't terminate the application on failure
+        ...
+
+      my_service2:
+        max_restarts: 3         # Restart a maximum of 3 times
+        allow_failures: False   # If more than 3 failures, terminate the application
         ...
 
 ``node_label``

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -966,7 +966,7 @@ public class ApplicationMaster {
     }
 
     public synchronized boolean isFailed() {
-      return numFailed > numRestarted;
+      return numFailed > numRestarted && !service.getAllowFailures();
     }
 
     public synchronized void notifyRunning(String dependency) {

--- a/java/src/main/java/com/anaconda/skein/Model.java
+++ b/java/src/main/java/com/anaconda/skein/Model.java
@@ -41,6 +41,7 @@ public class Model {
     private List<String> racks;
     private boolean relaxLocality;
     private int maxRestarts;
+    private boolean allowFailures;
     private Resource resources;
     private Map<String, LocalResource> localResources;
     private Map<String, String> env;
@@ -55,6 +56,7 @@ public class Model {
                    List<String> racks,
                    boolean relaxLocality,
                    int maxRestarts,
+                   boolean allowFailures,
                    Resource resources,
                    Map<String, LocalResource> localResources,
                    Map<String, String> env,
@@ -66,6 +68,7 @@ public class Model {
       this.racks = racks;
       this.relaxLocality = relaxLocality;
       this.maxRestarts = maxRestarts;
+      this.allowFailures = allowFailures;
       this.resources = resources;
       this.localResources = localResources;
       this.env = env;
@@ -102,6 +105,9 @@ public class Model {
 
     public void setMaxRestarts(int maxRestarts) { this.maxRestarts = maxRestarts; }
     public int getMaxRestarts() { return maxRestarts; }
+
+    public void setAllowFailures(boolean allowFailures) { this.allowFailures = allowFailures; }
+    public boolean getAllowFailures() { return allowFailures; }
 
     public void setResources(Resource resources) { this.resources = resources; }
     public Resource getResources() { return resources; }

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -277,6 +277,7 @@ public class MsgUtils {
         .addAllRacks(service.getRacks())
         .setRelaxLocality(service.getRelaxLocality())
         .setMaxRestarts(service.getMaxRestarts())
+        .setAllowFailures(service.getAllowFailures())
         .setResources(writeResources(service.getResources()))
         .putAllEnv(service.getEnv())
         .setScript(service.getScript())
@@ -300,6 +301,7 @@ public class MsgUtils {
         new ArrayList<String>(service.getRacksList()),
         service.getRelaxLocality(),
         service.getMaxRestarts(),
+        service.getAllowFailures(),
         readResources(service.getResources()),
         localResources,
         new HashMap<String, String>(service.getEnvMap()),

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -79,11 +79,12 @@ message Service {
   repeated string racks = 4;
   bool relax_locality = 5;
   int32 max_restarts = 6;
-  Resources resources = 7;
-  map<string, File> files = 8;
-  map<string, string> env = 9;
-  string script = 10;
-  repeated string depends = 11;
+  bool allow_failures = 7;
+  Resources resources = 8;
+  map<string, File> files = 9;
+  map<string, string> env = 10;
+  string script = 11;
+  repeated string depends = 12;
 }
 
 

--- a/skein/model.py
+++ b/skein/model.py
@@ -726,6 +726,11 @@ class Service(Specification):
         are only restarted on failure, and the cap is set for all containers in
         the service, not per container. Set to -1 to allow infinite restarts.
         Default is 0.
+    allow_failures : bool, optional
+        If False (default), the whole application will shutdown if the number
+        of failures for this service exceeds ``max_restarts``. Set to True to
+        keep the application running even if this service exceeds its failure
+        limit.
     node_label : str, optional
         The node label expression to use when requesting containers for this
         service. If not set, defaults to the application-level ``node_label``
@@ -743,14 +748,14 @@ class Service(Specification):
         are strictly enforced. Default is False.
     """
     __slots__ = ('resources', 'script', 'instances', 'files', 'env',
-                 'depends', 'max_restarts', 'node_label', 'nodes', 'racks',
-                 'relax_locality')
+                 'depends', 'max_restarts', 'allow_failures', 'node_label',
+                 'nodes', 'racks', 'relax_locality')
     _protobuf_cls = _proto.Service
 
     def __init__(self, resources=required, script=required, instances=1,
                  files=None, env=None, depends=None, max_restarts=0,
-                 node_label='', nodes=None, racks=None, relax_locality=False,
-                 commands=None):
+                 allow_failures=False, node_label='', nodes=None, racks=None,
+                 relax_locality=False, commands=None):
 
         if script is required and commands is not None:
             context.warn("The ``commands`` field for services is deprecated, "
@@ -766,6 +771,7 @@ class Service(Specification):
         self.env = {} if env is None else env
         self.depends = set() if depends is None else set(depends)
         self.max_restarts = max_restarts
+        self.allow_failures = allow_failures
         self.node_label = node_label
         self.nodes = [] if nodes is None else nodes
         self.racks = [] if racks is None else racks
@@ -782,6 +788,7 @@ class Service(Specification):
         self._check_is_list_of('racks', string)
         self._check_is_type('relax_locality', bool)
         self._check_is_bounded_int('max_restarts', min=-1)
+        self._check_is_type('allow_failures', bool)
 
         self._check_is_type('resources', Resources)
         self.resources._validate(is_request=True)
@@ -834,6 +841,7 @@ class Service(Specification):
                   'racks': list(obj.racks),
                   'relax_locality': obj.relax_locality,
                   'max_restarts': obj.max_restarts,
+                  'allow_failures': obj.allow_failures,
                   'resources': resources,
                   'files': files,
                   'env': dict(obj.env),

--- a/skein/model.py
+++ b/skein/model.py
@@ -146,7 +146,7 @@ def check_no_cycles(dependencies):
 
 
 def _infer_format(path, format='infer'):
-    if format is 'infer':
+    if format == 'infer':
         _, ext = os.path.splitext(path)
         if ext == '.json':
             format = 'json'


### PR DESCRIPTION
Adds support for allowing failures in a service. If set to True, the
application will not terminate if the number of failures for a service
exceeds `max_restarts` for that service. Default is False.

This is useful for things like `dask` workers, where we may want to
handle restart behavior manually instead of relying on skein to do it
for us.