### PR TITLE
Make generating new credentials threadsafe

### DIFF
--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -3,7 +3,9 @@ from __future__ import print_function, division, absolute_import
 import os
 import subprocess
 import time
+import warnings
 import weakref
+from multiprocessing.pool import Pool
 
 import pytest
 
@@ -103,6 +105,26 @@ def test_security_auto_inits(skein_config):
 
     assert not rec
     assert sec == sec2
+
+
+def _pool_initializer(config_dir):
+    skein.properties._mapping['config_dir'] = config_dir
+
+
+def _from_default_count_warnings(n):
+    with warnings.catch_warnings(record=True) as rec:
+        skein.Security.from_default()
+    return len(rec)
+
+
+def test_security_auto_inits_no_race_condition(tmpdir):
+    config_dir = str(tmpdir)
+    with Pool(processes=4, initializer=_pool_initializer,
+              initargs=(config_dir,)) as pool:
+        num_warnings = sum(pool.map(_from_default_count_warnings, range(8)))
+    # Only one process actually writes (and raises a warning)
+    # all others just read in credentials
+    assert num_warnings == 1
 
 
 def test_client(security, kinit, tmpdir):
@@ -632,10 +654,15 @@ def test_node_locality(client, strict):
 def test_set_application_progress(client):
     with run_application(client) as app:
         app.set_progress(0.5)
-        # Give the allocate loop time to update
-        time.sleep(2)
-        report = client.application_report(app.id)
-        assert report.progress == 0.5
+        # The report won't update until the allocator loop runs. Try a couple
+        # times.
+        for _ in range(6):
+            report = client.application_report(app.id)
+            if report.progress == 0.5:
+                break
+            time.sleep(1)
+        else:
+            assert report.progress == 0.5
 
         with pytest.raises(ValueError):
             app.set_progress(-0.5)

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -5,6 +5,7 @@ import subprocess
 import time
 import warnings
 import weakref
+from contextlib import closing
 from multiprocessing.pool import Pool
 
 import pytest
@@ -119,8 +120,9 @@ def _from_default_count_warnings(n):
 
 def test_security_auto_inits_no_race_condition(tmpdir):
     config_dir = str(tmpdir)
-    with Pool(processes=4, initializer=_pool_initializer,
-              initargs=(config_dir,)) as pool:
+    pool = Pool(processes=4, initializer=_pool_initializer,
+                initargs=(config_dir,))
+    with closing(pool):
         num_warnings = sum(pool.map(_from_default_count_warnings, range(8)))
     # Only one process actually writes (and raises a warning)
     # all others just read in credentials

--- a/skein/test/test_utils.py
+++ b/skein/test/test_utils.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, print_function, division
 
+import multiprocessing
 from datetime import timedelta
 
 from skein.utils import (humanize_timedelta, format_table,
-                         format_comma_separated_list)
+                         format_comma_separated_list, lock_file)
 
 
 def test_humanize_timedelta():
@@ -32,3 +33,69 @@ def test_format_comma_separated_list():
     assert format_comma_separated_list([None]) == 'None'
     assert format_comma_separated_list([None, False]) == 'None or False'
     assert format_comma_separated_list([None, False, True]) == 'None, False, or True'
+
+
+def test_lock_file_single_process(tmpdir):
+    path = str(tmpdir.join('lock'))
+    acquired = False
+    with lock_file(path):
+        acquired = True
+    assert acquired
+
+
+def test_lock_file_same_object_used_for_same_path(tmpdir):
+    path = str(tmpdir.join('lock'))
+    lock1 = lock_file(path)
+    lock2 = lock_file(path)
+    assert lock1 is lock2
+
+
+class Locker(multiprocessing.Process):
+    def __init__(self, path=None):
+        super(Locker, self).__init__()
+        self.path = path
+        self.daemon = True
+        self.parent_conn, self.child_conn = multiprocessing.Pipe()
+
+    def shutdown(self):
+        if not self.parent_conn.closed:
+            self.parent_conn.send('shutdown')
+            self.parent_conn.close()
+        self.join()
+
+    def run(self):
+        lock = lock_file(self.path)
+        while True:
+            msg = self.child_conn.recv()
+            if msg == 'acquire':
+                lock.acquire()
+                self.child_conn.send('acquired')
+            elif msg == 'release':
+                lock.release()
+                self.child_conn.send('released')
+            elif msg == 'shutdown':
+                break
+        self.child_conn.close()
+
+
+def test_lock_file_multiple_processes(tmpdir):
+    path = str(tmpdir.join('lock'))
+
+    lock = lock_file(path)
+
+    locker = Locker(path=path)
+    locker.start()
+    locker.parent_conn.send('acquire')
+    assert 'acquired' == locker.parent_conn.recv()
+    locker.parent_conn.send('release')
+    assert 'released' == locker.parent_conn.recv()
+
+    lock.acquire()
+    locker.parent_conn.send('acquire')
+    assert not locker.parent_conn.poll(0.1)
+    lock.release()
+    assert 'acquired' == locker.parent_conn.recv()
+    locker.parent_conn.send('release')
+    assert 'released' == locker.parent_conn.recv()
+    locker.shutdown()
+    locker.join()


### PR DESCRIPTION
Previously if multiple processes ran `Security.from_default()` for the first time concurrently, there'd be a race condition generating the new credentials. Now we use a file lock to synchronize between processes.

Fixes #144.