### PR TITLE
Remove deprecated functionality

### DIFF
--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -6,9 +6,6 @@ from .exceptions import (SkeinError, ConnectionError, DriverNotRunningError,
 from .model import (Security, ApplicationSpec, Service, File, Resources,
                     FileType, FileVisibility, ACLs, Master)
 
-# TODO: deprecated, remove after next release cycle
-from .exceptions import DaemonError, DaemonNotRunningError
-
 from ._version import get_versions
 __version__ = get_versions()['version']
 del get_versions

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -120,13 +120,10 @@ container = node(entry_subs, 'container', 'Manage application containers')
 kv = node(entry_subs, 'kv', 'Manage the key-value store')
 driver = node(entry_subs, 'driver', 'Manage the global driver')
 config = node(entry_subs, 'config', 'Manage configuration')
-daemon = node(entry_subs, 'daemon', 'DEPRECATED')
 
 ###################
 # DAEMON COMMANDS #
 ###################
-
-# TODO: daemon commands are deprecated, cleanup after next release cycle
 
 keytab = arg('--keytab', default=None, metavar='PATH',
              help=("Path to a keytab file to use when starting the driver. "
@@ -144,26 +141,8 @@ java_options = arg("--java-option", dest="java_options", action='append',
                          "multiple times."))
 
 
-def deprecate_daemon(name, func):
-    def inner(*args, **kwargs):
-        context.warn("`skein daemon %s` is deprecated, use `skein driver %s` instead"
-                     % (name, name))
-        return func(*args, **kwargs)
-    return inner
-
-
-def driver_and_daemon(name, help, *args):
-    def caller(func):
-        subcommand(daemon.subs,
-                   name,
-                   'DEPRECATED, use ``skein driver %s`` instead' % name,
-                   *args)(deprecate_daemon(name, func))
-        return subcommand(driver.subs, name, help, *args)(func)
-    return caller
-
-
-@driver_and_daemon('start', 'Start the skein driver',
-                   keytab, principal, log, log_level, java_options)
+@subcommand(driver.subs, 'start', 'Start the skein driver',
+            keytab, principal, log, log_level, java_options)
 def driver_start(keytab=None, principal=None, log=False,
                  log_level=None, java_options=None):
     print(Client.start_global_driver(keytab=keytab, principal=principal,
@@ -171,7 +150,8 @@ def driver_start(keytab=None, principal=None, log=False,
                                      java_options=java_options))
 
 
-@driver_and_daemon('address', 'The address of the running driver')
+@subcommand(driver.subs,
+            'address', 'The address of the running driver')
 def driver_address():
     address, _ = _read_driver()
     if address is None:
@@ -191,17 +171,19 @@ def driver_pid():
         print(pid)
 
 
-@driver_and_daemon('stop', 'Stop the skein driver',
-                   arg('--force', '-f', action='store_true',
-                       help=("Stop the process associated with the driver PID, "
-                             "even if unable to verify it corresponds to a "
-                             "skein driver")))
+@subcommand(driver.subs,
+            'stop', 'Stop the skein driver',
+            arg('--force', '-f', action='store_true',
+                help=("Stop the process associated with the driver PID, "
+                      "even if unable to verify it corresponds to a "
+                      "skein driver")))
 def driver_stop(force=False):
     Client.stop_global_driver(force=force)
 
 
-@driver_and_daemon('restart', 'Restart the skein driver',
-                   keytab, principal, log, log_level, java_options)
+@subcommand(driver.subs,
+            'restart', 'Restart the skein driver',
+            keytab, principal, log, log_level, java_options)
 def driver_restart(keytab=None, principal=None, log=False, log_level=None,
                    java_options=None):
     driver_stop()

--- a/skein/core.py
+++ b/skein/core.py
@@ -8,7 +8,6 @@ import signal
 import socket
 import struct
 import subprocess
-import warnings
 from contextlib import closing
 
 import grpc
@@ -466,18 +465,6 @@ class Client(_ClientBase):
             os.remove(os.path.join(properties.config_dir, 'driver'))
         except OSError:  # pragma: no cover
             pass
-
-    # TODO: deprecated, remove after next release cycle
-    @staticmethod
-    def start_global_daemon():  # pragma: no cover
-        warnings.warn("start_global_daemon is deprecated, use start_global_driver "
-                      "instead")
-        Client.start_global_driver()
-
-    @staticmethod
-    def stop_global_daemon():  # pragma: no cover
-        warnings.warn("stop_global_daemon is deprecated, use stop_global_driver instead")
-        Client.stop_global_driver()
 
     def __repr__(self):
         return 'Client<%s>' % self.address

--- a/skein/exceptions.py
+++ b/skein/exceptions.py
@@ -65,37 +65,6 @@ class ApplicationError(SkeinError):
     """Internal exceptions from the application master"""
 
 
-# TODO: DaemonError/DaemonNotRunningError are deprecated, remove after next
-# release cycle
-def _add_ABCMeta(cls):
-    """Use the metaclass ABCMeta for this class"""
-    from abc import ABCMeta
-    return ABCMeta(cls.__name__, cls.__bases__, cls.__dict__.copy())
-
-
-@_add_ABCMeta
-class DaemonError(DriverError):
-    """Deprecated, use DriverError instead"""
-    @classmethod
-    def __subclasshook__(cls, other):
-        warnings.warn("DaemonError is deprecated, use DriverError instead")
-        if other is DriverError:
-            return True
-        return NotImplemented
-
-
-@_add_ABCMeta
-class DaemonNotRunningError(DriverNotRunningError):
-    """Deprecated, use DriverNotRunningError instead"""
-    @classmethod
-    def __subclasshook__(cls, other):
-        warnings.warn("DaemonNotRunningError is deprecated, use "
-                      "DriverNotRunningError instead")
-        if other is DriverNotRunningError:
-            return True
-        return NotImplemented
-
-
 class _Context(object):
     def __init__(self):
         self.is_cli = False

--- a/skein/model.py
+++ b/skein/model.py
@@ -776,13 +776,7 @@ class Service(Specification):
     def __init__(self, resources=required, script=required, instances=1,
                  files=None, env=None, depends=None, max_restarts=0,
                  allow_failures=False, node_label='', nodes=None, racks=None,
-                 relax_locality=False, commands=None):
-
-        if script is required and commands is not None:
-            context.warn("The ``commands`` field for services is deprecated, "
-                         "use ``script`` instead")
-            script = '\n'.join(["set -x -e"] + commands)
-
+                 relax_locality=False):
         self._assign_required('resources', resources)
         self._assign_required('script', script)
         self.instances = instances
@@ -833,9 +827,6 @@ class Service(Specification):
         _origin = _pop_origin(kwargs)
         obj = obj.copy()
 
-        # deprecated
-        commands = obj.pop('commands', None)
-
         cls._check_keys(obj, cls.__slots__)
 
         resources = obj.pop('resources', None)
@@ -849,7 +840,6 @@ class Service(Specification):
 
         return cls(resources=resources,
                    files=files,
-                   commands=commands,
                    **obj)
 
     @classmethod

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -757,19 +757,6 @@ def test_security_specified(client):
     assert remote_security.key_file.source.startswith('hdfs')
 
 
-def test_daemon_errors_deprecated():
-    with pytest.warns(UserWarning):
-        assert isinstance(skein.DriverError(), skein.DaemonError)
-    with pytest.warns(UserWarning):
-        assert not isinstance(skein.SkeinError(), skein.DaemonError)
-
-    with pytest.warns(UserWarning):
-        assert isinstance(skein.DriverNotRunningError(),
-                          skein.DaemonNotRunningError)
-    with pytest.warns(UserWarning):
-        assert not isinstance(skein.SkeinError(), skein.DaemonNotRunningError)
-
-
 def test_master_driver_foo(client, tmpdir):
     filpath = str(tmpdir.join("dummy-file"))
     with open(filpath, 'w') as fil:

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -475,23 +475,6 @@ def test_service_roundtrip():
     assert s == s2
 
 
-def test_service_commands_deprecated():
-    script = ('set -x -e\n'
-              'command 1\n'
-              'command 2')
-
-    with pytest.warns(UserWarning):
-        s = Service(commands=['command 1', 'command 2'],
-                    resources=Resources(memory=1024, vcores=1))
-    assert s.script == script
-
-    with pytest.warns(UserWarning):
-        s = Service.from_dict({'resources': {'memory': 1024,
-                                             'vcores': 1},
-                               'commands': ['command 1', 'command 2']})
-    assert s.script == script
-
-
 def test_application_spec_from_yaml():
     spec = ApplicationSpec.from_yaml(app_spec)
     assert isinstance(spec, ApplicationSpec)


### PR DESCRIPTION
Removes previously deprecated functionality:
- `DaemonError`
- `DaemonNotRunningError`
- `Client.start_global_daemon`
- `Client.stop_global_daemon`
- `commands` parameter to `Service`
- `skein daemon` CLI commands