### PR TITLE
Support scaling by a delta instead of total count

### DIFF
--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -1044,7 +1044,7 @@ public class ApplicationMaster {
       return context;
     }
 
-    public List<Model.Container> scale(int count, int change) {
+    public List<Model.Container> scale(int count, int delta) {
       List<Model.Container> out =  new ArrayList<Model.Container>();
 
       // Any function that may remove containers needs to lock the kv store
@@ -1052,24 +1052,24 @@ public class ApplicationMaster {
       synchronized (keyValueStore) {
         synchronized (this) {
           int active = getNumActive();
-          if (change == 0) {
-            change = count - active;
+          if (delta == 0) {
+            delta = count - active;
           } else {
-            // If change would result in negative instances, we just scale to 0
-            change = Math.max(change, -active);
-            count = change + active;
+            // If delta would result in negative instances, we just scale to 0
+            delta = Math.max(delta, -active);
+            count = delta + active;
           }
-          LOG.info("Scaling service '{}' to {} instances, a change of {}.",
-                   name, count, change);
-          if (change > 0) {
+          LOG.info("Scaling service '{}' to {} instances, a delta of {}.",
+                   name, count, delta);
+          if (delta > 0) {
             // Scale up
-            for (int i = 0; i < change; i++) {
+            for (int i = 0; i < delta; i++) {
               out.add(addContainer());
               numTarget += 1;
             }
-          } else if (change < 0) {
+          } else if (delta < 0) {
             // Scale down
-            for (int i = change; i < 0; i++) {
+            for (int i = delta; i < 0; i++) {
               int instance;
               if (waiting.size() > 0) {
                 instance = Utils.popfirst(waiting);
@@ -1457,11 +1457,11 @@ public class ApplicationMaster {
         return;
       }
       int count = req.getCount();
-      int change = req.getChange();
-      if (change != 0) {
+      int delta = req.getDelta();
+      if (delta != 0) {
         if (count != 0) {
           resp.onError(Status.INVALID_ARGUMENT
-              .withDescription("Can't specify both count and change")
+              .withDescription("Can't specify both count and delta")
               .asRuntimeException());
           return;
         }
@@ -1474,7 +1474,7 @@ public class ApplicationMaster {
 
       Msg.ContainersResponse.Builder msg = Msg.ContainersResponse.newBuilder();
       ServiceTracker tracker = services.get(service);
-      List<Model.Container> containers = tracker.scale(count, change);
+      List<Model.Container> containers = tracker.scale(count, delta);
       // Lock on tracker to prevent containers from updating while writing. If
       // this proves costly, may want to copy beforehand.
       synchronized (tracker) {

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -454,7 +454,8 @@ message ContainersResponse {
 
 message ScaleRequest {
   string service_name = 1;
-  int32 instances = 2;
+  int32 count = 2;
+  int32 change = 3;
 }
 
 

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -455,7 +455,7 @@ message ContainersResponse {
 message ScaleRequest {
   string service_name = 1;
   int32 count = 2;
-  int32 change = 3;
+  int32 delta = 3;
 }
 
 

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -445,30 +445,30 @@ def test_dynamic_containers(client):
         # All completed containers have an exit message
         assert all(c.exit_message for c in killed)
 
-        # Add containers by change
+        # Add containers by delta
         ncurrent = len(app.get_containers())
-        new = app.scale('sleeper', change=2)
+        new = app.scale('sleeper', delta=2)
         assert len(new) == 2
         assert len(app.get_containers()) == ncurrent + 2
 
-        # Remove containers by change
+        # Remove containers by delta
         ncurrent = len(app.get_containers())
         assert ncurrent >= 1
-        res = app.scale('sleeper', change=-1)
+        res = app.scale('sleeper', delta=-1)
         assert len(res) == 1
         assert len(app.get_containers()) == ncurrent - 1
 
         # Removing more containers than active removes all containers
         ncurrent = len(app.get_containers())
-        res = app.scale('sleeper', change=-(ncurrent + 2))
+        res = app.scale('sleeper', delta=-(ncurrent + 2))
         assert len(res) == ncurrent
         assert len(app.get_containers()) == 0
 
-        # Can't specify both count and change
+        # Can't specify both count and delta
         with pytest.raises(ValueError):
-            app.scale('sleeper', count=2, change=2)
+            app.scale('sleeper', count=2, delta=2)
 
-        # Must specify either count and change
+        # Must specify either count or delta
         with pytest.raises(ValueError):
             app.scale('sleeper')
 


### PR DESCRIPTION
Support scaling a service by a delta in number of containers rather than
specifying the number of total containers. This can be useful if
container lifetimes are being managed by some external service rather
than the skein appmaster itself.