### PR TITLE
Fix skein.properties.container_dir

### DIFF
--- a/skein/core.py
+++ b/skein/core.py
@@ -81,7 +81,11 @@ class Properties(Mapping):
         if yarn_container_id is not None:
             for path in os.environ.get('LOCAL_DIRS', '').split(','):
                 check_dir = os.path.join(path, yarn_container_id)
-                if os.path.exists(check_dir):
+                # YARN will create all possible directories, but only populate
+                # one of them. We have to check that the files exist in the
+                # directory, rather than just that the directory exists.
+                if (os.path.exists(os.path.join(check_dir, '.skein.crt')) and
+                        os.path.exists(os.path.join(check_dir, '.skein.pem'))):
                     container_dir = check_dir
                     break
 

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -280,12 +280,13 @@ def test_appclient_and_security_in_container(monkeypatch, tmpdir, security):
     app_id = 'application_1526134340424_0012'
     container_id = 'container_1526134340424_0012_01_000005'
     address = 'edge.example.com:8765'
-    bad_dir = str(tmpdir.mkdir("nothing_in_here"))
+    bad_dir = tmpdir.mkdir("nothing_in_here")
+    bad_dir.mkdir(container_id)
 
     for key, val in [('SKEIN_APPLICATION_ID', app_id),
                      ('CONTAINER_ID', container_id),
                      ('SKEIN_APPMASTER_ADDRESS', address),
-                     ('LOCAL_DIRS', bad_dir)]:
+                     ('LOCAL_DIRS', str(bad_dir))]:
         monkeypatch.setenv(key, val)
 
     properties = Properties()


### PR DESCRIPTION
Fixes a bug (introduced in 0.6.0) in detecting the absolute path to the
container directory.  YARN (at least some versions) will create all
possible container directories (as listed in
`yarn.nodemanager.local-dirs`, but only populate one of them. Previously
we were just looking for a directory to exist when searching for the
container directory, now we look for the proper files as well.