### PR TITLE
Expose node information through client

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -128,6 +128,10 @@ Application Specification
     :members:
     :inherited-members:
 
+.. autoclass:: LogLevel
+    :members:
+    :inherited-members:
+
 .. autoclass:: Master
     :members:
     :inherited-members:
@@ -177,6 +181,22 @@ Application Responses
     :inherited-members:
 
 .. autoclass:: skein.model.ResourceUsageReport
+    :members:
+    :inherited-members:
+
+.. autoclass:: skein.model.ContainerState
+    :members:
+    :inherited-members:
+
+.. autoclass:: skein.model.Container
+    :members:
+    :inherited-members:
+
+.. autoclass:: skein.model.NodeState
+    :members:
+    :inherited-members:
+
+.. autoclass:: skein.model.NodeReport
     :members:
     :inherited-members:
 

--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -12,6 +12,8 @@ import org.apache.hadoop.yarn.api.records.FinalApplicationStatus;
 import org.apache.hadoop.yarn.api.records.LocalResource;
 import org.apache.hadoop.yarn.api.records.LocalResourceType;
 import org.apache.hadoop.yarn.api.records.LocalResourceVisibility;
+import org.apache.hadoop.yarn.api.records.NodeReport;
+import org.apache.hadoop.yarn.api.records.NodeState;
 import org.apache.hadoop.yarn.api.records.Resource;
 import org.apache.hadoop.yarn.api.records.URL;
 import org.apache.hadoop.yarn.api.records.YarnApplicationState;
@@ -180,6 +182,14 @@ public class MsgUtils {
     return null; // appease the compiler, but can't get here
   }
 
+  public static Msg.NodeState.Type writeNodeState(NodeState state) {
+    return Msg.NodeState.Type.valueOf(state.toString());
+  }
+
+  public static NodeState readNodeState(Msg.NodeState.Type state) {
+    return NodeState.valueOf(state.toString());
+  }
+
   public static Msg.ApplicationReport writeApplicationReport(
       ApplicationReport r) {
     return Msg.ApplicationReport.newBuilder()
@@ -229,6 +239,29 @@ public class MsgUtils {
     Msg.ApplicationsResponse.Builder builder = Msg.ApplicationsResponse.newBuilder();
     for (ApplicationReport report : reports) {
       builder.addReports(writeApplicationReport(report));
+    }
+    return builder.build();
+  }
+
+  public static Msg.NodeReport writeNodeReport(
+      NodeReport r) {
+    return Msg.NodeReport.newBuilder()
+      .setId(r.getNodeId().toString())
+      .setHttpAddress(r.getHttpAddress())
+      .setRackName(r.getRackName())
+      .addAllLabels(r.getNodeLabels())
+      .setState(writeNodeState(r.getNodeState()))
+      .setHealthReport(r.getHealthReport())
+      .setTotalResources(writeResources(r.getCapability()))
+      .setUsedResources(writeResources(r.getUsed()))
+      .build();
+  }
+
+  public static Msg.NodesResponse writeNodesResponse(
+      List<NodeReport> reports) {
+    Msg.NodesResponse.Builder builder = Msg.NodesResponse.newBuilder();
+    for (NodeReport report : reports) {
+      builder.addReports(writeNodeReport(report));
     }
     return builder.build();
   }

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -201,6 +201,32 @@ message ApplicationReport {
 }
 
 
+message NodeState {
+  enum Type {
+    DECOMMISSIONED = 0;
+    DECOMMISSIONING = 1;
+    LOST = 2;
+    NEW = 3;
+    REBOOTED = 4;
+    RUNNING = 5;
+    SHUTDOWN = 6;
+    UNHEALTHY = 7;
+  }
+}
+
+
+message NodeReport {
+  string id = 1;
+  string http_address = 2;
+  string rack_name = 3;
+  repeated string labels = 4;
+  NodeState.Type state = 5;
+  string health_report = 6;
+  Resources total_resources = 7;
+  Resources used_resources = 8;
+}
+
+
 // Driver only definitions
 
 
@@ -210,6 +236,8 @@ service Driver {
   rpc getStatus (Application) returns (ApplicationReport);
 
   rpc getApplications (ApplicationsRequest) returns (ApplicationsResponse);
+
+  rpc getNodes (NodesRequest) returns (NodesResponse);
 
   rpc submit (ApplicationSpec) returns (Application);
 
@@ -231,6 +259,16 @@ message ApplicationsRequest {
 
 message ApplicationsResponse {
   repeated ApplicationReport reports = 1;
+}
+
+
+message NodesRequest {
+  repeated NodeState.Type states = 1;
+}
+
+
+message NodesResponse {
+  repeated NodeReport reports = 1;
 }
 
 

--- a/skein/__init__.py
+++ b/skein/__init__.py
@@ -4,7 +4,7 @@ from .exceptions import (SkeinError, ConnectionError, DriverNotRunningError,
                          ApplicationNotRunningError, DriverError,
                          ApplicationError)
 from .model import (Security, ApplicationSpec, Service, File, Resources,
-                    FileType, FileVisibility, ACLs, Master)
+                    FileType, FileVisibility, ACLs, Master, LogLevel)
 
 from ._version import get_versions
 __version__ = get_versions()['version']

--- a/skein/model.py
+++ b/skein/model.py
@@ -1677,10 +1677,6 @@ class NodeReport(ProtobufMessage):
     ----------
     id : str
         The node id.
-    host : str
-        The node manager host for this node.
-    port : int
-        The node manager port for this node.
     http_address : str
         The http address to the node manager.
     rack_name : str
@@ -1720,7 +1716,7 @@ class NodeReport(ProtobufMessage):
 
     @property
     def host(self):
-        """The host for this node."""
+        """The node manager host for this node."""
         return self.id.split(':')[0]
 
     @property

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -5,7 +5,8 @@ from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
                         ResourceUsageReport, ApplicationReport, Application,
                         ApplicationsRequest, Url, ContainersRequest, Container,
                         ContainerInstance, ScaleRequest, ShutdownRequest,
-                        KillRequest, SetProgressRequest)
+                        KillRequest, SetProgressRequest, NodeState, NodeReport,
+                        NodesRequest)
 from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -190,6 +190,7 @@ def test_client_errors_nicely_if_not_logged_in(security, not_logged_in):
 
     with skein.Client(security=security) as client:
         for func, args in [('get_applications', ()),
+                           ('get_nodes', ()),
                            ('application_report', (appid,)),
                            ('connect', (appid,)),
                            ('kill_application', (appid,)),
@@ -268,6 +269,19 @@ def test_client_login_from_keytab(security, not_logged_in):
 
     with pytest.raises(ValueError):
         skein.Client(keytab=KEYTAB_PATH, security=security)
+
+
+def test_get_nodes(client):
+    nodes = client.get_nodes()
+    assert nodes
+
+    # Doesn't exist for Hadoop <= 2.8, should be empty list
+    nodes = client.get_nodes(states=['SHUTDOWN'])
+    assert not nodes
+
+    # Should still have results here
+    nodes = client.get_nodes(states=['SHUTDOWN', 'RUNNING'])
+    assert nodes
 
 
 def test_appclient_and_security_in_container(monkeypatch, tmpdir, security):

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -11,7 +11,7 @@ from skein.compatibility import UTC, math_ceil
 from skein.model import (ApplicationSpec, Service, Resources, File,
                          ApplicationState, FinalStatus, FileType, ACLs, Master,
                          Container, ApplicationReport, ResourceUsageReport,
-                         LogLevel, parse_memory, Security)
+                         NodeReport, LogLevel, parse_memory, Security)
 
 
 def indent(s, n):
@@ -656,3 +656,28 @@ def test_application_report():
     runtime = a.runtime
     after = datetime.datetime.now(UTC)
     assert (before - a.start_time) <= runtime <= (after - a.start_time)
+
+
+def test_node_report():
+    a = NodeReport(id='worker1.example.com:34721',
+                   http_address='worker1.example.com:8042',
+                   rack_name='/default-rack',
+                   labels={'gpu', 'fpga'},
+                   health_report='some words here',
+                   state='RUNNING',
+                   total_resources=Resources(memory=8192, vcores=8),
+                   used_resources=Resources(memory=0, vcores=0))
+
+    b = NodeReport(id='worker2.example.com:34721',
+                   http_address='worker2.example.com:8042',
+                   rack_name='/default-rack',
+                   state='NEW',
+                   labels=set(),
+                   health_report='',
+                   total_resources=Resources(memory=8192, vcores=8),
+                   used_resources=Resources(memory=0, vcores=0))
+
+    check_base_methods(a, b)
+
+    assert a.host == 'worker1.example.com'
+    assert a.port == 34721


### PR DESCRIPTION
Adds a method `skein.Client.get_nodes` for accessing information about nodes in the YARN cluster. Information exposed includes node hostnames, available resources, etc...

Fixes #155.