### PR TITLE
Add method to move application to another queue

### DIFF
--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -259,6 +259,8 @@ service Driver {
 
   rpc getAllQueues (Empty) returns (QueuesResponse);
 
+  rpc moveApplication (MoveRequest) returns (Empty);
+
   rpc submit (ApplicationSpec) returns (Application);
 
   rpc waitForStart (Application) returns (ApplicationReport);
@@ -299,6 +301,12 @@ message QueueRequest {
 
 message QueuesResponse {
   repeated Queue queues = 1;
+}
+
+
+message MoveRequest {
+  string id = 1;
+  string queue = 2;
 }
 
 

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -304,6 +304,15 @@ def application_status(app_id):
 
 
 @subcommand(application.subs,
+            'mv', 'Move a Skein application to a different queue',
+            app_id,
+            arg('queue', type=str, metavar='QUEUE',
+                help='The queue to move the application to.'))
+def application_move(app_id, queue):
+    get_driver().move_application(app_id, queue)
+
+
+@subcommand(application.subs,
             'kill', 'Kill a Skein application',
             app_id,
             arg('--user', default='', type=str,

--- a/skein/core.py
+++ b/skein/core.py
@@ -720,6 +720,18 @@ class Client(_ClientBase):
         resp = self._call('getStatus', proto.Application(id=app_id))
         return ApplicationReport.from_protobuf(resp)
 
+    def move_application(self, app_id, queue):
+        """Move an application to a different queue.
+
+        Parameters
+        ----------
+        app_id : str
+            The id of the application to move.
+        queue : str
+            The queue to move the application to.
+        """
+        self._call('moveApplication', proto.MoveRequest(id=app_id, queue=queue))
+
     def kill_application(self, app_id, user=""):
         """Kill an application.
 

--- a/skein/proto/__init__.py
+++ b/skein/proto/__init__.py
@@ -6,7 +6,8 @@ from .skein_pb2 import (Empty, FinalStatus, ApplicationState, Resources, File,
                         ApplicationsRequest, Url, ContainersRequest, Container,
                         ContainerInstance, ScaleRequest, ShutdownRequest,
                         KillRequest, SetProgressRequest, NodeState, NodeReport,
-                        NodesRequest, Queue, QueueRequest, QueuesResponse)
+                        NodesRequest, Queue, QueueRequest, QueuesResponse,
+                        MoveRequest)
 from .skein_pb2 import (GetRangeRequest, GetRangeResponse,
                         PutKeyRequest, PutKeyResponse,
                         DeleteRangeRequest, DeleteRangeResponse,

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -76,6 +76,7 @@ def global_client(kinit, tmpdir_factory):
                           'application status',
                           'application ls',
                           'application specification',
+                          'application mv',
                           'application kill',
                           'application shutdown',
                           'container',
@@ -334,6 +335,13 @@ def test_cli_application(tmpdir, capsys, global_client):
         out, err = capsys.readouterr()
         assert not err
         skein.ApplicationSpec.from_yaml(out)
+
+        # `skein application mv`
+        run_command('application mv %s apples' % app_id)
+        out, err = capsys.readouterr()
+        assert not out
+        assert not err
+        assert global_client.application_report(app_id).queue == 'apples'
 
         # `skein application shutdown`
         run_command('application shutdown %s' % app_id)


### PR DESCRIPTION
Adds support for moving an application between queues. This is doable
using either the python API (`skein.Client.move_application`) or the CLI
('skein application mv`).