### PR TITLE
Add filter methods to `Client.get_applications`

### DIFF
--- a/java/src/main/java/com/anaconda/skein/MsgUtils.java
+++ b/java/src/main/java/com/anaconda/skein/MsgUtils.java
@@ -236,15 +236,6 @@ public class MsgUtils {
       .build();
   }
 
-  public static Msg.ApplicationsResponse writeApplicationsResponse(
-      List<ApplicationReport> reports) {
-    Msg.ApplicationsResponse.Builder builder = Msg.ApplicationsResponse.newBuilder();
-    for (ApplicationReport report : reports) {
-      builder.addReports(writeApplicationReport(report));
-    }
-    return builder.build();
-  }
-
   public static Msg.NodeReport writeNodeReport(
       NodeReport r) {
     return Msg.NodeReport.newBuilder()

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -276,6 +276,13 @@ message Application {
 
 message ApplicationsRequest {
   repeated ApplicationState.Type states = 1;
+  string name = 2;
+  string user = 3;
+  string queue = 4;
+  int64 started_begin = 5;
+  int64 started_end = 6;
+  int64 finished_begin = 7;
+  int64 finished_end = 8;
 }
 
 

--- a/skein/cli.py
+++ b/skein/cli.py
@@ -283,15 +283,39 @@ def application_submit(spec):
 @subcommand(application.subs,
             'ls', 'List applications',
             arg('--all', '-a', action='store_true',
-                help=('Show all applications (default is only active '
-                      'applications)')),
-            arg("--state", "-s", action='append',
-                help=('Filter by application states. May be repeated '
-                      'to select multiple states.')))
-def application_ls(all=False, state=None):
+                help=('Show applications in all states (default is only '
+                      'active applications)')),
+            arg('--state', '-s', action='append',
+                help=('Select applications with this state. May be '
+                      'repeated to filter on multiple states.')),
+            arg('--name', help='Select applications with this name.'),
+            arg('--queue', help='Select applications with this queue.'),
+            arg('--user', help='Select applications with this user.'),
+            arg('--started-begin',
+                help=('Select applications that started after this datetime '
+                      '(inclusive). Accepts several date and time formats '
+                      '(e.g. ``YYYY-M-D H:M:S`` or ``H:M``). See the '
+                      'documentation for more information.')),
+            arg('--started-end',
+                help=('Select applications that started before this datetime '
+                      '(inclusive)')),
+            arg('--finished-begin',
+                help=('Select applications that finished after this datetime '
+                      '(inclusive)')),
+            arg('--finished-end',
+                help=('Select applications that finished before this datetime '
+                      '(inclusive)')))
+def application_ls(all=False, state=None, name=None, queue=None, user=None,
+                   started_begin=None, started_end=None, finished_begin=None,
+                   finished_end=None):
     if all and state is None:
         state = tuple(ApplicationState)
-    apps = get_driver().get_applications(states=state)
+
+    apps = get_driver().get_applications(
+        states=state, name=name, queue=queue, user=user,
+        started_begin=started_begin, started_end=started_end,
+        finished_begin=finished_begin, finished_end=finished_end
+    )
     _print_application_status(apps)
 
 

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -7,7 +7,7 @@ import pickle
 
 import pytest
 
-from skein.compatibility import UTC, math_ceil
+from skein.compatibility import math_ceil
 from skein.model import (ApplicationSpec, Service, Resources, File,
                          ApplicationState, FinalStatus, FileType, ACLs, Master,
                          Container, ApplicationReport, ResourceUsageReport,
@@ -566,10 +566,8 @@ def test_enums():
 
 
 def test_container():
-    start = datetime.datetime(2018, 6, 7, 23, 24, 25, 26 * 1000,
-                              tzinfo=UTC)
-    finish = datetime.datetime(2018, 6, 7, 23, 21, 25, 26 * 1000,
-                               tzinfo=UTC)
+    start = datetime.datetime(2018, 6, 7, 23, 24, 25, 26 * 1000)
+    finish = datetime.datetime(2018, 6, 7, 23, 21, 25, 26 * 1000)
 
     kwargs = dict(service_name="foo",
                   instance=0,
@@ -596,9 +594,9 @@ def test_container():
 
     assert c2.runtime == c2.finish_time - c2.start_time
 
-    before = datetime.datetime.now(UTC)
+    before = datetime.datetime.now()
     runtime = c.runtime
-    after = datetime.datetime.now(UTC)
+    after = datetime.datetime.now()
     assert (before - c.start_time) <= runtime <= (after - c.start_time)
 
     assert c3.runtime == datetime.timedelta(0)
@@ -621,8 +619,8 @@ def test_application_report():
                                 Resources(memory=256, vcores=2),
                                 Resources(memory=384, vcores=3))
 
-    start = datetime.datetime(2018, 6, 7, 23, 24, 25, 26 * 1000, tzinfo=UTC)
-    finish = datetime.datetime(2018, 6, 7, 23, 21, 25, 26 * 1000, tzinfo=UTC)
+    start = datetime.datetime(2018, 6, 7, 23, 24, 25, 26 * 1000)
+    finish = datetime.datetime(2018, 6, 7, 23, 21, 25, 26 * 1000)
 
     kwargs = dict(id='application_1528138529205_0001',
                   name='test',
@@ -652,9 +650,9 @@ def test_application_report():
     check_base_methods(a, b)
 
     assert b.runtime == b.finish_time - b.start_time
-    before = datetime.datetime.now(UTC)
+    before = datetime.datetime.now()
     runtime = a.runtime
-    after = datetime.datetime.now(UTC)
+    after = datetime.datetime.now()
     assert (before - a.start_time) <= runtime <= (after - a.start_time)
 
 

--- a/skein/test/test_utils.py
+++ b/skein/test/test_utils.py
@@ -1,16 +1,36 @@
 from __future__ import absolute_import, print_function, division
 
 import multiprocessing
-from datetime import timedelta
+from datetime import timedelta, datetime
 
+from skein.compatibility import UTC
 from skein.utils import (humanize_timedelta, format_table,
-                         format_comma_separated_list, lock_file)
+                         format_comma_separated_list, lock_file,
+                         datetime_from_millis, datetime_to_millis)
 
 
 def test_humanize_timedelta():
     assert humanize_timedelta(timedelta(0, 6)) == '6s'
     assert humanize_timedelta(timedelta(0, 601)) == '10m'
     assert humanize_timedelta(timedelta(0, 6001)) == '1h 40m'
+
+
+def test_datetime_conversion():
+    # Timezone naive
+    now = datetime.now()
+    now2 = datetime_from_millis(datetime_to_millis(now))
+    now3 = datetime_from_millis(datetime_to_millis(now2))
+    # Rounded to nearest millisecond
+    assert abs(now2 - now).total_seconds() < 0.001
+    assert now2 == now3
+
+    # Timezone aware
+    now = datetime.now(UTC)
+    now2 = datetime_from_millis(datetime_to_millis(now)).replace(tzinfo=UTC)
+    now3 = datetime_from_millis(datetime_to_millis(now2)).replace(tzinfo=UTC)
+    # Rounded to nearest millisecond
+    assert abs(now2 - now).total_seconds() < 0.001
+    assert now2 == now3
 
 
 def test_format_table():


### PR DESCRIPTION
Allows filtering applications on:

- state
- name
- user
- queue
- start and finish times

These filters are also exposed through the CLI.

Fixes #133.