### PR TITLE
Add skein version to jar

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.anaconda.skein</groupId>
   <artifactId>skein</artifactId>
-  <version>1.0-SNAPSHOT</version>
+  <version>UNKNOWN</version>
 
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -13,6 +13,7 @@
     <boringssl.version>2.0.17.Final</boringssl.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
     <hadoopVersion>2.7.2</hadoopVersion>
+    <skein.version>UNKNOWN</skein.version>
   </properties>
 
   <build>
@@ -91,6 +92,15 @@
                   </excludes>
                 </filter>
               </filters>
+
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Implementation-Title>${project.artifactId}</Implementation-Title>
+                    <Implementation-Version>${skein.version}</Implementation-Version>
+                  </manifestEntries>
+                </transformer>
+              </transformers>
 
               <relocations>
                 <relocation>

--- a/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
+++ b/java/src/main/java/com/anaconda/skein/ApplicationMaster.java
@@ -158,6 +158,8 @@ public class ApplicationMaster {
 
   /** Main entrypoint for the ApplicationMaster. **/
   public static void main(String[] args) {
+    LOG.info("Starting Skein version {}", Utils.getSkeinVersion());
+
     // Specify the netty native workdir. This is necessary for systems where
     // `/tmp` is not executable.
     Utils.configureNettyNativeWorkDir();

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -161,6 +161,8 @@ public class Driver {
 
   /** Main Entry Point. **/
   public static void main(String[] args) {
+    LOG.debug("Starting Skein version {}", Utils.getSkeinVersion());
+
     // Maybe specify the netty native workdir. This is necessary for systems
     // where `/tmp` is not executable.
     Utils.configureNettyNativeWorkDir();

--- a/java/src/main/java/com/anaconda/skein/Utils.java
+++ b/java/src/main/java/com/anaconda/skein/Utils.java
@@ -29,6 +29,10 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Utils {
+  public static String getSkeinVersion() {
+    return Utils.class.getPackage().getImplementationVersion();
+  }
+
   public static <T> T popfirst(Set<T> s) {
     for (T out: s) {
       s.remove(out);

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,8 @@ from setuptools.command.install import install as _install
 
 import versioneer
 
+VERSION = versioneer.get_version()
+
 ROOT_DIR = os.path.abspath(os.path.dirname(os.path.relpath(__file__)))
 JAVA_DIR = os.path.join(ROOT_DIR, 'java')
 JAVA_TARGET_DIR = os.path.join(JAVA_DIR, 'target')
@@ -79,6 +81,7 @@ class build_java(Command):
         self.mkpath(SKEIN_JAVA_DIR)
         try:
             code = subprocess.call(['mvn', '-f', os.path.join(JAVA_DIR, 'pom.xml'),
+                                    '-Dskein.version=%s' % VERSION,
                                     '--batch-mode', 'package'])
         except OSError as exc:
             if exc.errno == errno.ENOENT:
@@ -187,7 +190,7 @@ cmdclass.update({'build_java': build_java,    # directly build the java source
 
 
 setup(name='skein',
-      version=versioneer.get_version(),
+      version=VERSION,
       cmdclass=cmdclass,
       maintainer='Jim Crist',
       maintainer_email='jiminy.crist@gmail.com',


### PR DESCRIPTION
Adds the skein version (as determined by versioneer) to the jar, and
logs the version in both the driver and application master processes.
This is useful for debugging from logs, as it gives the exact commit
that was run to produce those logs.