### PR TITLE
Bind driver to 127.0.0.1 instead of localhost

### DIFF
--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -57,6 +57,7 @@ import org.slf4j.LoggerFactory;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.net.InetSocketAddress;
 import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
@@ -132,7 +133,7 @@ public class Driver {
         MAX_GRPC_EXECUTOR_THREADS,
         true);
 
-    server = NettyServerBuilder.forPort(0)
+    server = NettyServerBuilder.forAddress(new InetSocketAddress("127.0.0.1", 0))
         .sslContext(sslContext)
         .addService(new DriverImpl())
         .workerEventLoopGroup(eg)

--- a/skein/core.py
+++ b/skein/core.py
@@ -221,7 +221,7 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
     env['CLASSPATH'] = '%s:%s' % (_SKEIN_JAR, classpath)
 
     callback = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    callback.bind(('localhost', 0))
+    callback.bind(('127.0.0.1', 0))
     callback.listen(1)
 
     with closing(callback):
@@ -265,7 +265,7 @@ def _start_driver(security=None, set_global=False, keytab=None, principal=None,
         else:
             raise DriverError("Failed to start java process")
 
-    address = 'localhost:%d' % port
+    address = '127.0.0.1:%d' % port
 
     if set_global:
         Client.stop_global_driver()

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -44,8 +44,8 @@ def hadoop3():
 
 
 KEYTAB_PATH = "/home/testuser/testuser.keytab"
-HAS_KERBEROS = os.environ['HADOOP_TESTING_CONFIG'].lower() == 'kerberos'
-HADOOP3 = os.environ['HADOOP_TESTING_VERSION'].lower() == 'cdh6'
+HAS_KERBEROS = os.environ.get('HADOOP_TESTING_CONFIG', '').lower() == 'kerberos'
+HADOOP3 = os.environ.get('HADOOP_TESTING_VERSION', '').lower() == 'cdh6'
 
 
 def do_kinit():

--- a/skein/test/test_cli.py
+++ b/skein/test/test_cli.py
@@ -172,7 +172,7 @@ def test_cli_driver(capsys, skein_config):
         run_command('driver start')
         out, err = capsys.readouterr()
         assert "Skein global security credentials not found" in err
-        assert 'localhost' in out
+        assert '127.0.0.1' in out
 
         # Daemon start is idempotent
         run_command('driver start')
@@ -221,7 +221,7 @@ def test_cli_driver_force_stop(tmpdir, capsys):
         )
         sock = socket.socket()
         sock.bind(('', 0))
-        address = 'localhost:%d' % sock.getsockname()[1]
+        address = '127.0.0.1:%d' % sock.getsockname()[1]
         with closing(sock):
             # PID is not a skein driver
             _write_driver(address, proc.pid)
@@ -260,7 +260,7 @@ def test_cli_driver_after_bad_driver_file(cmd, tmpdir, capsys):
 
         sock = socket.socket()
         sock.bind(('', 0))
-        address = 'localhost:%d' % sock.getsockname()[1]
+        address = '127.0.0.1:%d' % sock.getsockname()[1]
 
         # Find a PID that doesn't exist
         pid = 1234

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -572,7 +572,7 @@ def test_container():
     kwargs = dict(service_name="foo",
                   instance=0,
                   yarn_container_id='container_1528138529205_0038_01_000001',
-                  yarn_node_http_address='localhost:14420',
+                  yarn_node_http_address='worker.example.com:14420',
                   exit_message="")
 
     c = Container(state='RUNNING',


### PR DESCRIPTION
This makes 2 major changes:

- Uses 127.0.0.1 explicitly instead of localhost for the driver address.
This (hopefully) removes issues of Java resolving to ipv6 and python
resolving to ipv4.
- Changes the driver to only listen locally, instead of on 0.0.0.0. Note
that this wasn't a security issue before (all communication was still
secured), but having the driver reachable from a different machine isn't
a use case we should support.

Fixes #165 