### PR TITLE
Make `skein.Client` picklable

### DIFF
--- a/skein/core.py
+++ b/skein/core.py
@@ -369,6 +369,9 @@ class Client(_ClientBase):
                 proc.wait()
             raise
 
+    def __reduce__(self):
+        return (type(self), (self.address, self.security))
+
     @classmethod
     def from_global_driver(self):
         """Connect to the global driver."""

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -2,6 +2,7 @@ from __future__ import print_function, division, absolute_import
 
 import datetime
 import os
+import pickle
 import subprocess
 import time
 import warnings
@@ -274,6 +275,16 @@ def test_client_login_from_keytab(security, not_logged_in):
 
     with pytest.raises(ValueError):
         skein.Client(keytab=KEYTAB_PATH, security=security)
+
+
+def test_client_picklable(client):
+    b = pickle.dumps(client)
+    client2 = pickle.loads(b)
+    assert client2.address == client.address
+    assert client2.security == client.security
+    assert client2._proc is None
+    # Smoketest
+    client2.get_applications()
 
 
 def test_get_nodes(client):


### PR DESCRIPTION
Unpickling will only work on the same machine the driver is running on.
This is mostly useful for starting a single temporary client and using
it in child processes via multiprocessing.

See https://github.com/jcrist/skein/issues/140#issuecomment-486669563