### PR TITLE
Support GPU and FPGA resources

### DIFF
--- a/docs/source/specification.rst
+++ b/docs/source/specification.rst
@@ -210,6 +210,16 @@ fields:
   of a core. Requests larger than the maximum allocation will error on
   application submission.
 
+- ``gpus``
+
+  The number of gpus to request. Requires Hadoop >= 3.1, sets resource
+  requirements for ``yarn.io/gpu``. Optional, default is 0.
+
+- ``fpgas``
+
+  The number of fpgas to request. Requires Hadoop >= 3.1, sets resource
+  requirements for ``yarn.io/fpga``. Optional, default is 0.
+
 **Example**
 
 .. code-block:: none

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -1069,7 +1069,15 @@ public class Driver {
         return;
       }
 
-      Model.ApplicationSpec spec = MsgUtils.readApplicationSpec(req);
+      Model.ApplicationSpec spec;
+      try {
+        spec = MsgUtils.readApplicationSpec(req);
+      } catch (Utils.UnsupportedFeatureException exc) {
+        resp.onError(Status.INVALID_ARGUMENT
+            .withDescription(exc.getMessage())
+            .asRuntimeException());
+        return;
+      }
 
       ApplicationId appId = null;
       try {

--- a/java/src/main/java/com/anaconda/skein/Utils.java
+++ b/java/src/main/java/com/anaconda/skein/Utils.java
@@ -29,6 +29,13 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public class Utils {
+  // An exception indicating an unsupported Hadoop feature was requested
+  public static class UnsupportedFeatureException extends IllegalArgumentException {
+    public UnsupportedFeatureException(String msg) {
+      super(msg);
+    }
+  }
+
   public static String getSkeinVersion() {
     return Utils.class.getPackage().getImplementationVersion();
   }

--- a/java/src/main/proto/skein.proto
+++ b/java/src/main/proto/skein.proto
@@ -41,6 +41,8 @@ message ApplicationState {
 message Resources {
   int32 memory = 1;
   int32 vcores = 2;
+  int64 gpus = 3;
+  int64 fpgas = 4;
 }
 
 

--- a/skein/model.py
+++ b/skein/model.py
@@ -527,14 +527,22 @@ class Resources(Specification):
         configuration one virtual core may map to a single actual core, or a
         fraction of a core. Requests larger than the maximum allocation will
         error on application submission.
+    gpus : int, optional
+        The number of gpus to request. Requires Hadoop >= 3.1, sets
+        resource requirements for ``yarn.io/gpu``. Default is 0.
+    fpgas : int, optional
+        The number of fpgas to request. Requires Hadoop >= 3.1, sets
+        resource requirements for ``yarn.io/fpga``. Default is 0.
     """
-    __slots__ = ('_memory', 'vcores')
-    _params = ('memory', 'vcores')
+    __slots__ = ('_memory', 'vcores', 'gpus', 'fpgas')
+    _params = ('memory', 'vcores', 'gpus', 'fpgas')
     _protobuf_cls = _proto.Resources
 
-    def __init__(self, memory=required, vcores=required):
+    def __init__(self, memory=required, vcores=required, gpus=0, fpgas=0):
         self._assign_required('memory', memory)
         self._assign_required('vcores', vcores)
+        self.gpus = gpus
+        self.fpgas = fpgas
         self._validate()
 
     @property
@@ -552,6 +560,8 @@ class Resources(Specification):
         min = 1 if is_request else 0
         self._check_is_bounded_int('vcores', min=min)
         self._check_is_bounded_int('memory', min=min)
+        self._check_is_bounded_int('gpus', min=0)
+        self._check_is_bounded_int('fpgas', min=0)
 
 
 class FileVisibility(Enum):

--- a/skein/objects.py
+++ b/skein/objects.py
@@ -187,6 +187,8 @@ class Base(object):
 
 
 class ProtobufMessage(Base):
+    __slots__ = ()
+
     @classmethod
     def from_protobuf(cls, msg):
         """Create an instance from a protobuf message."""
@@ -206,6 +208,8 @@ class ProtobufMessage(Base):
 
 class Specification(ProtobufMessage):
     """Base class for objects that are part of the specification"""
+    __slots__ = ()
+
     @classmethod
     def from_dict(cls, obj):
         """Create an instance from a dict.

--- a/skein/test/test_core.py
+++ b/skein/test/test_core.py
@@ -17,7 +17,8 @@ from skein.core import Properties
 from skein.exceptions import FileNotFoundError, FileExistsError
 from skein.utils import pid_exists
 from skein.test.conftest import (run_application, wait_for_containers,
-                                 wait_for_completion, get_logs, KEYTAB_PATH)
+                                 wait_for_completion, get_logs, KEYTAB_PATH,
+                                 HADOOP3)
 
 
 def test_properties():
@@ -1132,3 +1133,23 @@ def test_move_application(client):
     with pytest.raises(ValueError) as exc:
         client.move_application("oh no", "default")
     assert "Invalid" in str(exc.value)
+
+
+def test_hadoop3_resource(client):
+    spec = skein.ApplicationSpec(
+        name="test_hadoop3_resources",
+        master=skein.Master(
+            resources=skein.Resources(
+                memory='32 MiB',
+                vcores=1,
+                gpus=1
+            ),
+            script="sleep infinity"
+        )
+    )
+    with pytest.raises(ValueError) as exc:
+        client.submit(spec)
+    if HADOOP3:
+        assert "Resource 'yarn.io/gpu'" in str(exc.value)
+    else:
+        assert "Custom resources not supported"

--- a/skein/test/test_model.py
+++ b/skein/test/test_model.py
@@ -127,7 +127,9 @@ def test_parse_memory():
 def test_resources():
     r = Resources(memory=1024, vcores=1)
     r2 = Resources(memory=1024, vcores=2)
+    r3 = Resources(memory=1, vcores=2, gpus=3, fpgas=4)
     check_specification_methods(r, r2)
+    check_specification_methods(r3, r2)
 
 
 def test_resources_invariants():


### PR DESCRIPTION
Adds (limited) support for Hadoop 3 resource requests. Currently only
the builtin resource extensions (gpu and fpga) are supported, true
custom requests could be added later with greater effort.

If the version of hadoop or the configuration don't support these
resources, a nice error is thrown.

Fixes #154.