### PR TITLE
Fix our templates after JS upgrade

### DIFF
--- a/java/src/main/resources/kv.mustache.html
+++ b/java/src/main/resources/kv.mustache.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <link rel="stylesheet" href="webjars/bootstrap/4.1.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="webjars/bootstrap/4.3.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.css">
 
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
@@ -87,7 +87,7 @@
       </table>
     </div>
 
-    <script src="webjars/jquery/3.0.0/jquery.min.js"></script>
-    <script src="webjars/bootstrap/4.1.1/js/bootstrap.bundle.min.js"></script>
+    <script src="webjars/jquery/3.4.1/jquery.min.js"></script>
+    <script src="webjars/bootstrap/4.3.1/js/bootstrap.bundle.min.js"></script>
   </body>
 </html>

--- a/java/src/main/resources/overview.mustache.html
+++ b/java/src/main/resources/overview.mustache.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
 
-    <link rel="stylesheet" href="webjars/bootstrap/4.1.1/css/bootstrap.min.css">
+    <link rel="stylesheet" href="webjars/bootstrap/4.3.1/css/bootstrap.min.css">
     <link rel="stylesheet" href="webjars/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css">
 
     <link rel="icon" type="image/png" sizes="32x32" href="favicon-32x32.png">
@@ -252,8 +252,8 @@
       {{/services}}
     </div>
 
-    <script src="webjars/jquery/3.0.0/jquery.min.js"></script>
-    <script src="webjars/bootstrap/4.1.1/js/bootstrap.bundle.min.js"></script>
+    <script src="webjars/jquery/3.4.1/jquery.min.js"></script>
+    <script src="webjars/bootstrap/4.3.1/js/bootstrap.bundle.min.js"></script>
     <script>
       $(document).ready(function () {
         // Need to try session storage, as it may exist but fail in private mode


### PR DESCRIPTION
Due to not testing how the pages rendered in our test suite, things were
broken after the javascript versions were updated. This fixes our
templates to properly use the new JS versions. I have tested this
manually and everything looks ok.

In reference to https://github.com/jcrist/skein/issues/184#issuecomment-525759704