### PR TITLE
Tornado Auth mixins

### DIFF
--- a/continuous_integration/travis/docker_install.sh
+++ b/continuous_integration/travis/docker_install.sh
@@ -1,14 +1,18 @@
 #!/usr/bin/env bash
 set -xe
 
-packages="grpcio pyyaml cryptography pytest flake8 requests pyarrow nomkl"
-
-if [[ $1 == "2.7" ]]; then
-    conda create -n py27 python=2.7 $packages
-    source activate py27
-else
-    conda install $packages
-fi
+conda install \
+    grpcio \
+    pyyaml \
+    cryptography \
+    pytest \
+    flake8 \
+    requests \
+    pyarrow \
+    nomkl \
+    pykerberos \
+    requests-kerberos \
+    tornado
 
 pip install grpcio-tools
 

--- a/continuous_integration/travis/script.sh
+++ b/continuous_integration/travis/script.sh
@@ -9,6 +9,8 @@ if [[ "$DOCS" != "true" ]]; then
     # kinit if needed
     if [[ "$CLUSTER_CONFIG" == "kerberos" ]]; then
         htcluster exec -- kinit testuser -kt testuser.keytab
+        htcluster exec -u root cp /etc/hadoop/conf/master-keytabs/HTTP.keytab /home/testuser/HTTP.keytab
+        htcluster exec -u root chmod 644 /home/testuser/HTTP.keytab
     fi
     # Run py.test inside docker
     htcluster exec -- $CONDA_ENV/bin/py.test skein/skein/ -vv

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -232,3 +232,11 @@ Exceptions
 
 .. autoexception:: ApplicationError
     :show-inheritance:
+
+
+Tornado Utilities
+-----------------
+
+.. autofunction:: skein.tornado.init_kerberos
+
+.. autoclass:: skein.tornado.KerberosMixin

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -239,4 +239,6 @@ Tornado Utilities
 
 .. autofunction:: skein.tornado.init_kerberos
 
-.. autoclass:: skein.tornado.KerberosMixin
+.. autoclass:: skein.tornado.KerberosAuthMixin
+
+.. autoclass:: skein.tornado.SimpleAuthMixin

--- a/skein/test/conftest.py
+++ b/skein/test/conftest.py
@@ -42,8 +42,16 @@ def hadoop3():
 
 
 KEYTAB_PATH = "/home/testuser/testuser.keytab"
+HTTP_KEYTAB_PATH = "/home/testuser/HTTP.keytab"
 HAS_KERBEROS = os.environ.get('HADOOP_TESTING_CONFIG', '').lower() == 'kerberos'
 HADOOP3 = os.environ.get('HADOOP_TESTING_VERSION', '').lower() == 'cdh6'
+
+
+@pytest.fixture(scope="session")
+def http_keytab():
+    if not os.path.exists(HTTP_KEYTAB_PATH):
+        pytest.skip("HTTP keytab not found")
+    return HTTP_KEYTAB_PATH
 
 
 def do_kinit():

--- a/skein/test/test_tornado.py
+++ b/skein/test/test_tornado.py
@@ -2,18 +2,18 @@ import os
 import sys
 
 import pytest
-pytest.importorskip("kerberos")
 pytest.importorskip("tornado")
-requests_kerberos = pytest.importorskip("requests_kerberos")
 
 import requests
 from tornado import ioloop, web
 
 import skein.tornado
-from skein.tornado import init_kerberos, KerberosMixin
+from skein.tornado import init_kerberos, KerberosAuthMixin, SimpleAuthMixin
 
 
 def test_tornado_init_kerberos(has_kerberos_enabled, http_keytab, monkeypatch):
+    pytest.importorskip("kerberos")
+
     # Kerberos not installed
     with monkeypatch.context() as m:
         m.setitem(sys.modules, "kerberos", None)
@@ -47,18 +47,21 @@ def test_tornado_init_kerberos(has_kerberos_enabled, http_keytab, monkeypatch):
         assert skein.tornado._SERVICE_NAME == "HTTP@foo.bar.baz"
 
 
-class HelloHandler(KerberosMixin, web.RequestHandler):
+class HelloHandler(KerberosAuthMixin, web.RequestHandler):
     @web.authenticated
     def get(self):
         self.write("Hello %s" % self.current_user)
 
 
 def test_tornado_kerberos(has_kerberos_enabled, http_keytab):
+    pytest.importorskip("kerberos")
+    requests_kerberos = pytest.importorskip("requests_kerberos")
+
     init_kerberos(keytab=http_keytab, hostname="master.example.com")
 
     # Serve web application
     app = web.Application([("/", HelloHandler)])
-    app.listen(8888, "edge.example.com")
+    server = app.listen(8888, "edge.example.com")
 
     async def test():
         auth = requests_kerberos.HTTPKerberosAuth(hostname_override="master.example.com")
@@ -68,4 +71,34 @@ def test_tornado_kerberos(has_kerberos_enabled, http_keytab):
 
     loop = ioloop.IOLoop.current()
     resp = loop.run_sync(test)
+    server.stop()
+
     assert resp.text == "Hello testuser"
+
+
+class SimpleHelloHandler(SimpleAuthMixin, web.RequestHandler):
+    @web.authenticated
+    def get(self):
+        self.write("Hello %s" % self.current_user)
+
+
+def test_tornado_simple():
+    # Serve web application
+    app = web.Application([("/", SimpleHelloHandler)])
+    server = app.listen(8888, "edge.example.com")
+
+    async def test():
+        resp1 = await ioloop.IOLoop.current().run_in_executor(
+            None, lambda: requests.get("http://edge.example.com:8888?user.name=testuser")
+        )
+        resp2 = await ioloop.IOLoop.current().run_in_executor(
+            None, lambda: requests.get("http://edge.example.com:8888")
+        )
+        return resp1, resp2
+
+    loop = ioloop.IOLoop.current()
+    resp1, resp2 = loop.run_sync(test)
+    server.stop()
+
+    assert resp1.text == "Hello testuser"
+    assert resp2.status_code == 401

--- a/skein/test/test_tornado.py
+++ b/skein/test/test_tornado.py
@@ -1,0 +1,71 @@
+import os
+import sys
+
+import pytest
+pytest.importorskip("kerberos")
+pytest.importorskip("tornado")
+requests_kerberos = pytest.importorskip("requests_kerberos")
+
+import requests
+from tornado import ioloop, web
+
+import skein.tornado
+from skein.tornado import init_kerberos, KerberosMixin
+
+
+def test_tornado_init_kerberos(has_kerberos_enabled, http_keytab, monkeypatch):
+    # Kerberos not installed
+    with monkeypatch.context() as m:
+        m.setitem(sys.modules, "kerberos", None)
+        with pytest.raises(ImportError):
+            init_kerberos()
+
+    # Keytab not specified
+    with monkeypatch.context() as m:
+        m.delenv("KRB5_KTNAME", raising=False)
+        with pytest.raises(ValueError):
+            init_kerberos()
+
+    # Keytab doesn't exist
+    with monkeypatch.context() as m:
+        m.delenv("KRB5_KTNAME", raising=False)
+        with pytest.raises(FileNotFoundError):
+            init_kerberos(keytab="/path/to/missing/file")
+
+    # Keytab specified via environment variable
+    with monkeypatch.context() as m:
+        m.setenv("KRB5_KTNAME", http_keytab)
+        init_kerberos()
+        assert os.environ["KRB5_KTNAME"] == http_keytab
+
+    # Keytab specified manually
+    with monkeypatch.context() as m:
+        m.delenv("KRB5_KTNAME", raising=False)
+        init_kerberos(keytab=http_keytab, hostname="foo.bar.baz")
+        assert os.environ["KRB5_KTNAME"] == http_keytab
+        # Service name set appropriately
+        assert skein.tornado._SERVICE_NAME == "HTTP@foo.bar.baz"
+
+
+class HelloHandler(KerberosMixin, web.RequestHandler):
+    @web.authenticated
+    def get(self):
+        self.write("Hello %s" % self.current_user)
+
+
+def test_tornado_kerberos(has_kerberos_enabled, http_keytab):
+    init_kerberos(keytab=http_keytab, hostname="master.example.com")
+
+    # Serve web application
+    app = web.Application([("/", HelloHandler)])
+    app.listen(8888, "edge.example.com")
+
+    async def test():
+        auth = requests_kerberos.HTTPKerberosAuth(hostname_override="master.example.com")
+        return await ioloop.IOLoop.current().run_in_executor(
+            None, lambda: requests.get("http://edge.example.com:8888", auth=auth)
+        )
+
+    loop = ioloop.IOLoop.current()
+    resp = loop.run_sync(test)
+    assert resp.text == "Hello testuser"

--- a/skein/tornado.py
+++ b/skein/tornado.py
@@ -1,0 +1,177 @@
+import logging
+import os
+from socket import gethostname
+
+from .exceptions import FileNotFoundError
+
+
+logger = logging.getLogger("tornado.application")
+
+
+__all__ = ("KerberosMixin", "init_kerberos")
+
+
+# The global service name, set by `init_kerberos`
+_SERVICE_NAME = None
+
+
+def init_kerberos(keytab=None, service="HTTP", hostname=None):
+    """Initialize Kerberos authentication settings.
+
+    Should be called once on process startup, sets global settings.
+
+    Parameters
+    ----------
+    keytab : str, optional
+        Path to the keytab file. If not set, will check the ``KRB5_KTNAME``
+        environment variable, and error otherwise.
+    hostname : str, optional
+        The hostname. If not provided, will be inferred from the system.
+    service : str, optional
+        The service name. The default of ``"HTTP"`` is usually sufficient.
+    """
+    # Ensure kerberos installed
+    try:
+        import kerberos  # noqa
+    except ImportError as exc:
+        raise type(exc)(
+            "Failed to import `kerberos`. Please install `pykerberos` via:\n"
+            "  conda install pykerberos\n"
+            "or\n"
+            "  pip install pykerberos"
+        )
+
+    # Ensure keytab set, set environment variable if needed
+    if keytab is not None:
+        keytab = os.path.abspath(os.path.expanduser(keytab))
+        os.environ["KRB5_KTNAME"] = keytab
+    elif "KRB5_KTNAME" in os.environ:
+        keytab = os.environ["KRB5_KTNAME"]
+    else:
+        raise ValueError(
+            "keytab not specified, and `KRB5_KTNAME` environment variable not set"
+        )
+
+    # Ensure keytab exists
+    if not os.path.exists(keytab):
+        raise FileNotFoundError("No keytab found at %s" % keytab)
+
+    # Infer hostname if needed
+    if hostname is None:
+        hostname = gethostname()
+
+    # Set global service name
+    global _SERVICE_NAME
+    _SERVICE_NAME = "%s@%s" % (service, hostname)
+
+
+class KerberosMixin(object):
+    """A ``tornado.web.RequestHandler`` mixin for authenticating with Kerberos.
+
+    Examples
+    --------
+    A simple hello-world application:
+
+    .. code-block:: python
+
+      from skein.tornado import init_kerberos, KerberosMixin
+      from tornado import web, ioloop
+
+      # Create a handler with the KerberosMixin as a base class
+      class HelloHandler(KerberosMixin, web.RequestHandler):
+          @web.authenticated
+          def get(self):
+              self.write("Hello %s" % self.current_user)
+
+      if __name__ == "__main__":
+          # Initialize kerberos once per application
+          init_kerberos(keytab="/path/to/my/service.keytab")
+
+          # Serve web application
+          app = web.Application([("/", HelloHandler)])
+          app.listen(8888)
+          ioloop.IOLoop.current().start()
+    """
+
+    def _raise_auth_error(self, err):
+        from tornado import web
+        logger.error("Kerberos failure: %s", err)
+        raise web.HTTPError(500, "Error during kerberos authentication")
+
+    def _raise_auth_required(self):
+        from tornado import web
+        self.set_status(401)
+        self.write("Authentication required")
+        self.set_header("WWW-Authenticate", "Negotiate")
+        raise web.Finish()
+
+    def get_current_user(self):
+        """An implementation of ``get_current_user`` using kerberos.
+
+        Calls out to ``get_current_user_kerberos``, override if you want to
+        support multiple authentication methods.
+        """
+        return self.get_current_user_kerberos()
+
+    def get_current_user_kerberos(self):
+        """Authenticate the current user using kerberos.
+
+        Returns
+        -------
+        user : str
+            The current user name.
+        """
+        import kerberos
+
+        auth_header = self.request.headers.get("Authorization")
+        if not auth_header:
+            return self._raise_auth_required()
+
+        auth_type, auth_key = auth_header.split(" ", 1)
+        if auth_type != "Negotiate":
+            return self._raise_auth_required()
+
+        if _SERVICE_NAME is None:
+            raise RuntimeError(
+                "Kerberos not initialized, must call `init_kerberos` before "
+                "serving requests"
+            )
+
+        gss_context = None
+        try:
+            # Initialize kerberos context
+            rc, gss_context = kerberos.authGSSServerInit(_SERVICE_NAME)
+
+            # NOTE: Per the pykerberos documentation, the return code should be
+            # checked after each step. However, after reading the pykerberos
+            # code no method used here will ever return anything but
+            # AUTH_GSS_COMPLETE (all other cases will raise an exception).  We
+            # keep these checks in just in case pykerberos changes its behavior
+            # to match its docs, but they likely never will trigger.
+
+            if rc != kerberos.AUTH_GSS_COMPLETE:
+                return self._raise_auth_error(
+                    "GSS server init failed, return code = %r" % rc
+                )
+
+            # Challenge step
+            rc = kerberos.authGSSServerStep(gss_context, auth_key)
+            if rc != kerberos.AUTH_GSS_COMPLETE:
+                return self._raise_auth_error(
+                    "GSS server step failed, return code = %r" % rc
+                )
+            gss_key = kerberos.authGSSServerResponse(gss_context)
+
+            # Retrieve user name
+            fulluser = kerberos.authGSSServerUserName(gss_context)
+            user = fulluser.split("@", 1)[0]
+
+            # Complete the protocol by responding with the Negotiate header
+            self.set_header("WWW-Authenticate", "Negotiate %s" % gss_key)
+        except kerberos.GSSError as err:
+            return self._raise_auth_error(err)
+        finally:
+            if gss_context is not None:
+                kerberos.authGSSServerClean(gss_context)
+
+        return user


### PR DESCRIPTION
Adds mixins for `kerberos` and `simple` authentication, for writing tornado-backed services that launch YARN jobs, or interact with YARN in any way.

I've written a few services lately like this, and have just been copying around the same short authenticator classes, figured it might make sense to push these upstream. This adds no dependencies, the addition of these mixin classes is purely for ease of use when writing YARN-backed services.