### PR TITLE
Get also mapreduce history service DelegationToken

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -390,6 +390,13 @@
       <scope>provided</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.apache.hadoop</groupId>
+      <artifactId>hadoop-mapreduce-client-common</artifactId>
+      <version>${hadoopVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+
     <!--Test Dependencies-->
     <dependency>
       <groupId>junit</groupId>

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -14,6 +14,8 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslProvider;
+
+import org.apache.commons.lang.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
@@ -22,8 +24,15 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.io.DataOutputBuffer;
 import org.apache.hadoop.io.Text;
+import org.apache.hadoop.mapred.Master;
 import org.apache.hadoop.mapreduce.security.TokenCache;
+import org.apache.hadoop.mapreduce.v2.api.HSClientProtocol;
+import org.apache.hadoop.mapreduce.v2.api.MRClientProtocol;
+import org.apache.hadoop.mapreduce.v2.api.protocolrecords.GetDelegationTokenRequest;
+import org.apache.hadoop.mapreduce.v2.jobhistory.JHAdminConfig;
+import org.apache.hadoop.net.NetUtils;
 import org.apache.hadoop.security.Credentials;
+import org.apache.hadoop.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.token.Token;
 import org.apache.hadoop.security.token.TokenIdentifier;
@@ -48,6 +57,9 @@ import org.apache.hadoop.yarn.client.api.YarnClient;
 import org.apache.hadoop.yarn.client.api.YarnClientApplication;
 import org.apache.hadoop.yarn.conf.YarnConfiguration;
 import org.apache.hadoop.yarn.exceptions.YarnException;
+import org.apache.hadoop.yarn.factories.RecordFactory;
+import org.apache.hadoop.yarn.factory.providers.RecordFactoryProvider;
+import org.apache.hadoop.yarn.ipc.YarnRPC;
 import org.apache.hadoop.yarn.security.client.RMDelegationTokenIdentifier;
 import org.apache.hadoop.yarn.util.ConverterUtils;
 import org.apache.log4j.Level;
@@ -62,6 +74,7 @@ import java.net.Socket;
 import java.nio.ByteBuffer;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -364,7 +377,8 @@ public class Driver {
     } else {
       return UserGroupInformation.createProxyUser(spec.getUser(), ugi).doAs(
         new PrivilegedExceptionAction<ApplicationId>() {
-          public ApplicationId run() throws IOException, YarnException {
+          public ApplicationId run() throws IOException, YarnException,
+              InterruptedException {
             return submitApplicationInner(getYarnClient(), getFs(), spec);
           }
         });
@@ -372,7 +386,8 @@ public class Driver {
   }
 
   private ApplicationId submitApplicationInner(YarnClient yarnClient,
-      FileSystem fs, Model.ApplicationSpec spec) throws IOException, YarnException {
+      FileSystem fs, Model.ApplicationSpec spec) throws IOException, YarnException,
+      InterruptedException {
     // First validate the spec request
     spec.validate();
 
@@ -452,8 +467,53 @@ public class Driver {
     return appId;
   }
 
+  private MRClientProtocol instantiateHistoryProxy()
+      throws IOException {
+    final String serviceAddr = conf.get(JHAdminConfig.MR_HISTORY_ADDRESS);
+    if (StringUtils.isEmpty(serviceAddr)) {
+      return null;
+    }
+    LOG.debug("Connecting to HistoryServer at: " + serviceAddr);
+    final YarnRPC rpc = YarnRPC.create(conf);
+    LOG.debug("Connected to HistoryServer at: " + serviceAddr);
+    UserGroupInformation currentUser = UserGroupInformation.getCurrentUser();
+    return currentUser.doAs(new PrivilegedAction<MRClientProtocol>() {
+      @Override
+      public MRClientProtocol run() {
+        return (MRClientProtocol) rpc.getProxy(HSClientProtocol.class,
+            NetUtils.createSocketAddr(serviceAddr), conf);
+      }
+    });
+  }
+
+  private Token<?> getDelegationTokenFromHS(MRClientProtocol hsProxy)
+      throws IOException, InterruptedException {
+    final RecordFactory recordFactory = RecordFactoryProvider.getRecordFactory(null);
+    GetDelegationTokenRequest request;
+    request = recordFactory.newRecordInstance(GetDelegationTokenRequest.class);
+    request.setRenewer(Master.getMasterPrincipal(conf));
+    org.apache.hadoop.yarn.api.records.Token mrDelegationToken;
+    mrDelegationToken = hsProxy.getDelegationToken(request).getDelegationToken();
+    return ConverterUtils.convertFromYarn(mrDelegationToken, hsProxy.getConnectAddress());
+  }
+
+
+  private void addMapReduceHistoryToken(Credentials credentials)
+    throws IOException, InterruptedException {
+    // RPC to history server
+    MRClientProtocol hsProxy = instantiateHistoryProxy();
+    if (UserGroupInformation.isSecurityEnabled() && (hsProxy != null)) {
+      Text hsService = SecurityUtil.buildTokenService(hsProxy.getConnectAddress());
+      if (credentials.getToken(hsService) == null) {
+        credentials.addToken(hsService, getDelegationTokenFromHS(hsProxy));
+        // }
+      }
+    }
+  }
+
   private ByteBuffer collectTokens(YarnClient yarnClient, FileSystem fs,
-      Model.ApplicationSpec spec) throws IOException, YarnException {
+      Model.ApplicationSpec spec) throws IOException, YarnException,
+      InterruptedException {
     // Collect security tokens as needed
     LOG.debug("Collecting filesystem delegation tokens");
     Credentials credentials = UserGroupInformation.getCurrentUser().getCredentials();
@@ -483,6 +543,7 @@ public class Driver {
       );
       credentials.addToken(rmDelegationTokenService, rmToken);
     }
+    addMapReduceHistoryToken(credentials);
 
     DataOutputBuffer dob = new DataOutputBuffer();
     credentials.writeTokenStorageToStream(dob);


### PR DESCRIPTION
This PR adds DelegationToken for the MapReduce History Server when submitting a new application

**My use case**
I call skein from a periodic job written in python to archive some files in HDFS using hadoop archive. The goal is to reduce the number of files in HDFS.
I call from a Skein Service the hadoop command `hadoop archive` that launches a Map Reduce job that creates the archive.
MapReduce jobs do some connections to the MapReduce History Server. It needs a delegation token to authenticate to this service. For this reason, I would like skein also to create a delegation token for this service.

**Implementation details**
The code is adapted from the hadoop mapreduce project. Unfortunately, I need some functions that are private. That's why I adapted the code in skein. 
Original sourcefile: https://github.com/apache/hadoop/blob/branch-2.7.3/hadoop-mapreduce-project/hadoop-mapreduce-client/hadoop-mapreduce-client-jobclient/src/main/java/org/apache/hadoop/mapred/YARNRunner.java#L183
If the MapReduce History Server address is not present in the hadoop configuration files. The code does nothing.

**How did I test it ?**
I tested it by running a skein service that do a `subprocess.check_output` that triggers the `hadoop archive` command.