### PR TITLE
feat(mapr): support mapr security

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -13,8 +13,17 @@
     <boringssl.version>2.0.17.Final</boringssl.version>
     <jetty.version>9.2.10.v20150310</jetty.version>
     <hadoopVersion>2.7.2</hadoopVersion>
+    <mapr.version>6.1.0-mapr</mapr.version>
     <skein.version>UNKNOWN</skein.version>
   </properties>
+
+  <repositories>
+    <repository>
+      <id>mapr</id>
+      <name>MapR maven repository</name>
+      <url>https://repository.mapr.com/nexus/content/groups/mapr-public</url>
+    </repository>
+  </repositories>
 
   <build>
     <resources>
@@ -394,6 +403,13 @@
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-yarn-common</artifactId>
       <version>${hadoopVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>com.mapr.hadoop</groupId>
+      <artifactId>maprfs</artifactId>
+      <version>${mapr.version}</version>
       <scope>provided</scope>
     </dependency>
 


### PR DESCRIPTION
This commit is to support running skein in mapr secure cluster.
The version suported is mapr data fabric 6.1.0

This commit introduces a check in Driver class for MapR distribution.
Then use ClientSecurity class to check if the user has a valid
MapR ticket available for job submission.

Fixes #234