### PR TITLE
feat(driver): make skein staging directory configurable

### DIFF
--- a/java/pom.xml
+++ b/java/pom.xml
@@ -405,5 +405,19 @@
       <scope>test</scope>
     </dependency>
 
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-api-mockito2</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.powermock</groupId>
+      <artifactId>powermock-module-junit4</artifactId>
+      <version>2.0.9</version>
+      <scope>test</scope>
+    </dependency>
+
   </dependencies>
 </project>

--- a/java/src/main/java/com/anaconda/skein/Driver.java
+++ b/java/src/main/java/com/anaconda/skein/Driver.java
@@ -315,7 +315,9 @@ public class Driver {
   }
 
   public Path getAppDir(FileSystem fs, ApplicationId appId) {
-    return new Path(fs.getHomeDirectory(), ".skein/" + appId.toString());
+    String  skeinStagingDir = System.getenv("SKEIN_STAGING_DIR");
+    Path stagingPath = (skeinStagingDir == null) ? fs.getHomeDirectory() : new Path(skeinStagingDir);
+    return new Path(stagingPath, ".skein/" + appId.toString());
   }
 
   public Map<String, String> getApplicationLogs(

--- a/java/src/test/java/com/anaconda/skein/TestDriver.java
+++ b/java/src/test/java/com/anaconda/skein/TestDriver.java
@@ -1,0 +1,53 @@
+package com.anaconda.skein;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.when;
+
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.yarn.api.records.ApplicationId;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ System.class, Driver.class })
+public class TestDriver {
+
+  @Test
+  public void testGetAppDirWithEnv() {
+    FileSystem fs = Mockito.mock(FileSystem.class);
+    ApplicationId appId = Mockito.mock(ApplicationId.class);
+    PowerMockito.mockStatic(System.class);
+
+    String stagingDir = "/skein_staging_dir_from_env";
+    when(appId.toString()).thenReturn("application_01234");
+    when(System.getenv("SKEIN_STAGING_DIR")).thenReturn(stagingDir);
+
+    Driver driver = new Driver();
+    Path actual = driver.getAppDir(fs, appId);
+    Path expected = new Path(stagingDir, ".skein/application_01234");
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  public void testGetAppDirWithNoEnv() {
+
+    FileSystem fs = Mockito.mock(FileSystem.class);
+    ApplicationId appId = Mockito.mock(ApplicationId.class);
+    PowerMockito.mockStatic(System.class);
+
+    String homeDir = "/myhomedir";
+    when(fs.getHomeDirectory()).thenReturn(new Path(homeDir));
+    when(appId.toString()).thenReturn("application_01234");
+    when(System.getenv("SKEIN_STAGING_DIR")).thenReturn(null);
+
+    Driver driver = new Driver();
+    Path actual = driver.getAppDir(fs, appId);
+    Path expected = new Path(homeDir, ".skein/application_01234");
+    assertEquals(actual, expected);
+  }
+}


### PR DESCRIPTION
This change introduces an environment variable SKEIN_STAGING_DIR
to the Driver. If the variable is set, Driver will use the value
to create the staging directory. If the variable is not set, the
Driver falls back to fs.getHomeDir() to create the staging
directory.

Closes #237