### PR TITLE
Add ping method in python Client

### DIFF
--- a/skein/core.py
+++ b/skein/core.py
@@ -845,6 +845,13 @@ class Client(_ClientBase):
         """
         self._call('kill', proto.KillRequest(id=app_id, user=user))
 
+    def ping(self):
+        try:
+            # Ping server to check connection
+            self._call('ping', proto.Empty())
+        except Exception:
+            raise
+
 
 class ApplicationClient(_ClientBase):
     """A client for the application master.


### PR DESCRIPTION
This PR is to add ping method in python Client to check connection with remote application.

Currently the `ping` method is not provided in python client. I think it is very useful to supervise remote application.  
I think skein is a great framework. BTW I implemented a [yarn provisioner](https://github.com/huage1994/skein_provisioner) based on skein and use `ping` method to check connection with the remote kernel.
